### PR TITLE
fix: replace reduce with aggregate to better support older spark versions

### DIFF
--- a/sparkdq/checks/row_level/contained_checks/is_contained_in_check.py
+++ b/sparkdq/checks/row_level/contained_checks/is_contained_in_check.py
@@ -40,7 +40,7 @@ class IsContainedInCheck(BaseRowCheck):
         """
         conditions = [F.col(column).isin(values) for column, values in self.allowed_values.items()]
 
-        overall_condition = F.reduce(F.array(*conditions), F.lit(True), lambda acc, x: acc & x)
+        overall_condition = F.aggregate(F.array(*conditions), F.lit(True), lambda acc, x: acc & x)
 
         return self.with_check_result_column(df, overall_condition)
 

--- a/sparkdq/checks/row_level/contained_checks/is_not_contained_in_check.py
+++ b/sparkdq/checks/row_level/contained_checks/is_not_contained_in_check.py
@@ -38,7 +38,7 @@ class IsNotContainedInCheck(BaseRowCheck):
         """
         conditions = [~F.col(column).isin(values) for column, values in self.forbidden_values.items()]
 
-        overall_condition = F.reduce(F.array(*conditions), F.lit(True), lambda acc, x: acc & x)
+        overall_condition = F.aggregate(F.array(*conditions), F.lit(True), lambda acc, x: acc & x)
 
         return self.with_check_result_column(df, overall_condition)
 

--- a/sparkdq/checks/row_level/null_checks/not_null_check.py
+++ b/sparkdq/checks/row_level/null_checks/not_null_check.py
@@ -65,7 +65,7 @@ class NotNullCheck(BaseRowCheck):
         not_null_checks = F.array(*[F.col(c).isNotNull() for c in self.columns])
 
         # Reduce the array by OR-ing all not-null checks
-        any_not_null_expr = F.reduce(not_null_checks, F.lit(False), lambda acc, x: acc | x)
+        any_not_null_expr = F.aggregate(not_null_checks, F.lit(False), lambda acc, x: acc | x)
 
         return self.with_check_result_column(df, any_not_null_expr)
 

--- a/sparkdq/checks/row_level/null_checks/null_check.py
+++ b/sparkdq/checks/row_level/null_checks/null_check.py
@@ -60,7 +60,7 @@ class NullCheck(BaseRowCheck):
         null_checks = F.array(*[F.col(c).isNull() for c in self.columns])
 
         # Reduce the array by OR-ing all null checks
-        any_null_expr = F.reduce(null_checks, F.lit(False), lambda acc, x: acc | x)
+        any_null_expr = F.aggregate(null_checks, F.lit(False), lambda acc, x: acc | x)
 
         return self.with_check_result_column(df, any_null_expr)
 

--- a/sparkdq/checks/utils/base_comparison_check.py
+++ b/sparkdq/checks/utils/base_comparison_check.py
@@ -84,7 +84,7 @@ class BaseComparisonCheck(BaseRowCheck, ABC):
         column_exprs = F.array(*[self.comparison_condition(self._apply_cast(F.col(c))) for c in self.columns])
 
         # Reduce (aggregate) the array of boolean expressions into a single boolean expression
-        result_expr = F.reduce(column_exprs, F.lit(False), lambda acc, x: acc | x)
+        result_expr = F.aggregate(column_exprs, F.lit(False), lambda acc, x: acc | x)
 
         return self.with_check_result_column(df, result_expr)
 

--- a/sparkdq/engine/batch/check_runner.py
+++ b/sparkdq/engine/batch/check_runner.py
@@ -141,7 +141,7 @@ class BatchCheckRunner:
         if not fail_flags:
             return df.withColumn("_dq_passed", F.lit(True))
 
-        combined_flag = F.reduce(F.array(*fail_flags), F.lit(False), lambda acc, x: acc | x)
+        combined_flag = F.aggregate(F.array(*fail_flags), F.lit(False), lambda acc, x: acc | x)
 
         return df.withColumn("_dq_passed", ~combined_flag)
 


### PR DESCRIPTION
# 🚀 Replace reduce with aggregate


---

## 📌 What does this PR do?

<!-- Please provide a concise description of your changes.  
Example: "Adds a new numeric-between-check for row-level validation." -->

Replace reduce with aggregate


Reduce is a function introduced in spark 3.5. Older version cannot use that. In order to make the tool be used by more people, we can use aggregate function instead. The function is basically the same as reduce. 


---

## 🧪 Checklist

- [x] I followed the project's coding style.
- [ ] I added new unit tests for the changes (if applicable).
- [x] All existing and new tests pass (`pytest --cov=sparkdq`).
- [ ] I updated the documentation (if applicable).
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

---

## 🔎 Related Issues

<!-- Link to related issues, e.g.:  
"Fixes #42" or "Related to #99" -->

---
Related to https://github.com/sparkdq-community/sparkdq/issues/31


