### PR TITLE
chore(test): enable branch coverage in pyproject.toml and simplify te…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         run: uv sync --group test
 
       - name: Run unit tests
-        run: uv run pytest --cov=sparkdq -v --cov-report=term --cov-branch --cov-report=xml
+        run: uv run pytest --cov -v --cov-report=term --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ filterwarnings = [
 
 [tool.coverage.run]
 source = ["sparkdq"]
+branch = true
 
 [tool.coverage.report]
 exclude_lines = [

--- a/uv.lock
+++ b/uv.lock
@@ -2045,7 +2045,7 @@ wheels = [
 
 [[package]]
 name = "sparkdq"
-version = "0.5.2"
+version = "0.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
# Enable Branch Coverage and Simplify Test Configuration

## ✨ Summary

This MR enables **branch coverage** in the `coverage.py` configuration and simplifies the test execution setup.

---

## ✅ Changes

- Added `branch = true` under `[tool.coverage.run]` in `pyproject.toml` to enable branch coverage by default
- Moved common `pytest` arguments into `[tool.pytest.ini_options]` via `addopts`
- Cleaned up GitHub Actions job by removing redundant CLI parameters (`--cov-branch`, etc.)

---

## 🔍 Why?

- Makes branch coverage consistent across local runs, CI, and IDEs
- Reduces duplication and simplifies the test job definition
- Prepares the project for better integration with reporting tools (e.g. Codecov, Sonar)

---

## 🧪 How to test

Run the following command locally (or check the CI):

```bash
uv run pytest
