### PR TITLE
chore(pyproject.toml): add build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.7.0"
 description = "A declarative PySpark framework for row- and aggregate-level data quality validation."
 authors = [{ name = "Marcel Kennert", email = "marcel.kennert@gmx.de" }]
 readme = "README.md"
+license = {file = "LICENSE"}
 keywords = [
   "data-quality",
   "data-validation",
@@ -67,6 +68,10 @@ jupyter = [
     "ipykernel>=6.20.0,<7.0.0"
 ]
 
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [tool.mypy]
 python_version = "3.11"
 exclude = ["docs", "tests", "examples"]
@@ -87,7 +92,7 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W"]
-extend-ignore = ["N812", "N803"]
+extend-ignore = ["N812", "N803"]  # N812: lowercase imported as non-lowercase, N803: argument name should be lowercase
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## ✨ Add license declaration and improve build system metadata

### Summary

This MR enhances the `pyproject.toml` by explicitly declaring the project's license file and refining the build system configuration.

### Changes

- ✅ Added license metadata via `license = {file = "LICENSE"}` to clearly specify the license file for the project.
- ✅ Updated `[build-system]` section to define `requires = ["hatchling"]` and `build-backend = "hatchling.build"` explicitly for better build tool compatibility and clarity.

### Motivation

- Including the license file explicitly improves compatibility with PyPI and tooling that parses license metadata (e.g. SPDX consumers, GitHub metadata bots).
- Explicit build-system metadata ensures compatibility with modern Python packaging workflows and helps external tools like `pip` and `uv` resolve build dependencies correctly.

### Notes

These are non-functional changes that improve project metadata quality. No runtime or behavioral changes are introduced.

---
