### PR TITLE
refactor(checks): dynamically register CheckConfig classes in __init_…

### DIFF
--- a/sparkdq/checks/__init__.py
+++ b/sparkdq/checks/__init__.py
@@ -1,65 +1,42 @@
-from .aggregate.completeness_checks.columns_are_complete_check import ColumnsAreCompleteCheckConfig
-from .aggregate.completeness_checks.completeness_ratio_check import CompletenessRatioCheckConfig
-from .aggregate.count_checks.count_between_check import RowCountBetweenCheckConfig
-from .aggregate.count_checks.count_exact_check import RowCountExactCheckConfig
-from .aggregate.count_checks.count_max_check import RowCountMaxCheckConfig
-from .aggregate.count_checks.count_min_check import RowCountMinCheckConfig
-from .aggregate.freshness_checks.freshness_check import FreshnessCheckConfig
-from .aggregate.schema_checks.column_presence_check import ColumnPresenceCheckConfig
-from .aggregate.schema_checks.schema_check import SchemaCheckConfig
-from .aggregate.uniqueness_checks.distinct_ratio_check import DistinctRatioCheckConfig
-from .aggregate.uniqueness_checks.unique_ratio_check import UniqueRatioCheckConfig
-from .aggregate.uniqueness_checks.unique_rows_check import UniqueRowsCheckConfig
-from .row_level.columns_comparison_checks.column_less_than import ColumnLessThanCheckConfig
-from .row_level.contained_checks.is_contained_in_check import IsContainedInCheckConfig
-from .row_level.contained_checks.is_not_contained_in_check import IsNotContainedInCheckConfig
-from .row_level.date_checks.date_between_check import DateBetweenCheckConfig
-from .row_level.date_checks.date_max_check import DateMaxCheckConfig
-from .row_level.date_checks.date_min_check import DateMinCheckConfig
-from .row_level.null_checks.exactly_one_not_null_check import ExactlyOneNotNullCheckConfig
-from .row_level.null_checks.not_null_check import NotNullCheckConfig
-from .row_level.null_checks.null_check import NullCheckConfig
-from .row_level.numeric_checks.numeric_between_check import NumericBetweenCheckConfig
-from .row_level.numeric_checks.numeric_max_check import NumericMaxCheckConfig
-from .row_level.numeric_checks.numeric_min_check import NumericMinCheckConfig
-from .row_level.string_checks.between_length_check import StringLengthBetweenCheckConfig
-from .row_level.string_checks.max_length_check import StringMaxLengthCheckConfig
-from .row_level.string_checks.min_length_check import StringMinLengthCheckConfig
-from .row_level.string_checks.regex_match_check import RegexMatchCheckConfig
-from .row_level.timestamp_checks.timestamp_between_check import TimestampBetweenCheck
-from .row_level.timestamp_checks.timestamp_max_check import TimestampMaxCheckConfig
-from .row_level.timestamp_checks.timestamp_min_check import TimestampMinCheckConfig
+"""
+This module serves as the dynamic entry point for the sparkdq.checks subpackage.
 
-__all__ = [
-    "NullCheckConfig",
-    "NotNullCheckConfig",
-    "ExactlyOneNotNullCheckConfig",
-    "RowCountMinCheckConfig",
-    "RowCountMaxCheckConfig",
-    "RowCountExactCheckConfig",
-    "RowCountBetweenCheckConfig",
-    "NumericMinCheckConfig",
-    "NumericMaxCheckConfig",
-    "NumericBetweenCheckConfig",
-    "DateMinCheckConfig",
-    "DateMaxCheckConfig",
-    "DateBetweenCheckConfig",
-    "TimestampMinCheckConfig",
-    "TimestampMaxCheckConfig",
-    "TimestampBetweenCheck",
-    "SchemaCheckConfig",
-    "ColumnPresenceCheckConfig",
-    "IsContainedInCheckConfig",
-    "IsNotContainedInCheckConfig",
-    "ColumnLessThanCheckConfig",
-    "StringMinLengthCheckConfig",
-    "StringMaxLengthCheckConfig",
-    "StringLengthBetweenCheckConfig",
-    "RegexMatchCheckConfig",
-    "UniqueRowsCheckConfig",
-    "UniqueRatioCheckConfig",
-    "CompletenessRatioCheckConfig",
-    "ColumnsAreCompleteCheckConfig",
-    "DistinctRatioCheckConfig",
-    "FreshnessCheckConfig",
-]
+It recursively traverses all submodules within the sparkdq.checks package to identify and register
+all classes that inherit from either `BaseRowCheckConfig` or `BaseAggregateCheckConfig`.
+
+Each valid check configuration class is added to the module’s global namespace and included in
+`__all__`, ensuring it becomes part of the public API.
+
+This approach eliminates the need for manual imports and `__all__` maintenance, making the system
+easy to extend as new check classes are added. It also allows developers and users to import any
+check configuration directly from the top-level `sparkdq` namespace.
+
+This mechanism incurs a small runtime overhead during the initial import of `sparkdq.checks`,
+but improves maintainability and scalability significantly in large modular frameworks.
+"""
+
+import importlib
+import inspect
+import pkgutil
+
+from sparkdq.core.base_config import BaseAggregateCheckConfig, BaseRowCheckConfig
+
+__all__ = []
+
+base_classes = (BaseRowCheckConfig, BaseAggregateCheckConfig)
+
+
+def is_valid_check_class(obj: object) -> bool:
+    """
+    Checks whether obj is a class that inherits from one of the base config classes,
+    excluding the base classes themselves.
+    """
+    return inspect.isclass(obj) and issubclass(obj, base_classes) and obj not in base_classes
+
+
+# Recursively scan all submodules and collect valid check config classes
+for _, module_name, _ in pkgutil.walk_packages(__path__, prefix=f"{__name__}."):  # type: ignore
+    module = importlib.import_module(module_name)
+    for name, obj in inspect.getmembers(module, is_valid_check_class):
+        globals()[name] = obj
+        __all__.append(name)

--- a/tests/unit/checks/test_public_api.py
+++ b/tests/unit/checks/test_public_api.py
@@ -1,0 +1,36 @@
+import importlib
+import inspect
+import pkgutil
+
+from sparkdq import checks
+from sparkdq.core.base_config import BaseAggregateCheckConfig, BaseRowCheckConfig
+
+
+def get_all_check_config_subclasses(package) -> set[str]:
+    """
+    Scans the entire sparkdq package for subclasses of BaseRowCheckConfig or BaseAggregateCheckConfig.
+    Returns the set of class names that should be publicly exposed.
+    """
+    base_classes = (BaseRowCheckConfig, BaseAggregateCheckConfig)
+    subclasses = set()
+
+    for _, module_name, _ in pkgutil.walk_packages(package.__path__, prefix=package.__name__ + "."):
+        module = importlib.import_module(module_name)
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if issubclass(obj, base_classes) and obj not in base_classes:
+                subclasses.add(name)
+    return subclasses
+
+
+def test_all_check_configs_are_exposed_in_public_api():
+    """
+    Validates that all subclasses of BaseRowCheckConfig or BaseAggregateCheckConfig
+    are included in sparkdq.__all__.
+    """
+    # Arrange
+    expected_exports = get_all_check_config_subclasses(checks)
+    actual_exports = set(checks.__all__)
+
+    # Assert
+    missing = expected_exports - actual_exports
+    assert not missing, f"Missing public exports in __all__: {missing}"


### PR DESCRIPTION
## ✅ Refactor: Dynamically register CheckConfig classes in `sparkdq.checks.__init__`

### Summary
This merge request replaces the manual imports and static `__all__` list in `sparkdq.checks.__init__` with a dynamic mechanism. It automatically discovers and registers all subclasses of `BaseRowCheckConfig` and `BaseAggregateCheckConfig` by recursively scanning the module hierarchy.

### Changes
- ♻️ Replaced all manual imports in `sparkdq.checks.__init__` with dynamic import logic using `pkgutil`, `importlib`, and `inspect`
- ✅ Added type-safe filtering to include only subclasses of `BaseRowCheckConfig` or `BaseAggregateCheckConfig`
- 🧪 Introduced a unit test (`test_public_api.py`) that asserts all valid check configs are properly exposed via `sparkdq.checks.__all__`

### Benefits
- 🧼 Reduces manual maintenance and risk of forgetting to expose newly implemented checks
- 📈 Improves scalability as new check modules are added
- 🛡 Ensures public API is always consistent with implementation via test coverage

### Notes
- The dynamic import incurs a negligible startup cost during the first import of `sparkdq.checks`, which is acceptable in exchange for maintainability.
