### PR TITLE
feat: update ColumnLessThanCheck to use a limit expression

### DIFF
--- a/docs/source/built_in_checks/checks/columns_comparison/column_less.rst
+++ b/docs/source/built_in_checks/checks/columns_comparison/column_less.rst
@@ -6,16 +6,17 @@ Column Less Than Check
 **Check**: ``column-less-than-check``
 
 **Purpose**: Ensures that values in one column are strictly less than (or less than or equal to)
-the values in another column.
+the values in another column or the result of evaluating a Spark SQL expression.
 
 .. note::
 
-    * Rows with ``null`` values in either column are treated as **invalid** and will fail the check.
+    * Rows with ``null`` values in either column or the limit result are treated as **invalid**
+    and will fail the check.
 
     * Use the ``inclusive`` flag to control whether equality (``<=``) is permitted.
 
-        - ``inclusive: false``: requires ``smaller_column < greater_column``  
-        - ``inclusive: true``: allows ``smaller_column <= greater_column``
+        - ``inclusive: false``: requires ``column < limit``  
+        - ``inclusive: true``: allows ``column <= limit``
 
 Python Configuration
 --------------------
@@ -25,11 +26,29 @@ Python Configuration
     from sparkdq.checks import ColumnLessThanCheckConfig
     from sparkdq.core import Severity
 
+    # Simple column comparison
     ColumnLessThanCheckConfig(
         check_id="pickup-before-dropoff",
-        smaller_column="pickup_datetime",
-        greater_column="dropoff_datetime",
+        column="pickup_datetime",
+        limit="dropoff_datetime",
         inclusive=False,  # use True to allow equality
+        severity=Severity.CRITICAL
+    )
+
+    # Expression with mathematical operation
+    ColumnLessThanCheckConfig(
+        check_id="price-with-margin",
+        column="cost_price",
+        limit="selling_price * 0.8",
+        inclusive=True,  # use False to require strict less than
+        severity=Severity.CRITICAL
+    )
+
+    ColumnLessThanCheckConfig(
+        check_id="score-validation",
+        column="user_score",
+        limit="CASE WHEN level='expert' THEN max_score ELSE max_score * 0.9 END",
+        inclusive=False,
         severity=Severity.CRITICAL
     )
 
@@ -40,8 +59,22 @@ Declarative Configuration
 
     - check: column-less-than-check
       check-id: pickup-before-dropoff
-      smaller-column: pickup_datetime
-      greater-column: dropoff_datetime
+      column: pickup_datetime
+      limit: dropoff_datetime
+      inclusive: false
+      severity: critical
+
+    - check: column-less-than-check
+      check-id: price-with-margin
+      column: cost_price
+      limit: selling_price * 0.8
+      inclusive: true
+      severity: critical
+
+    - check: column-less-than-check
+      check-id: score-validation
+      column: user_score
+      limit: CASE WHEN level='expert' THEN max_score ELSE max_score * 0.9 END
       inclusive: false
       severity: critical
 
@@ -51,5 +84,11 @@ Typical Use Cases
 * ✅ Enforce correct ordering of timestamps, such as ensuring pickup time is before dropoff time.
 
 * ✅ Detect incorrect or corrupted ranges in financial or numeric fields.
+
+* ✅ Validate business rules with dynamic limits, such as ensuring selling
+price is within acceptable margins of cost price (e.g., selling_price < cost_price * 1.2).
+
+* ✅ Apply conditional validation logic based on categories or statuses
+(e.g., score < CASE WHEN level='expert' THEN max_score ELSE max_score * 0.9 END).
 
 * ✅ Prevent invalid or logically inconsistent data entries in business-critical systems.

--- a/sparkdq/checks/row_level/columns_comparison_checks/column_less_than.py
+++ b/sparkdq/checks/row_level/columns_comparison_checks/column_less_than.py
@@ -69,7 +69,8 @@ class ColumnLessThanCheck(BaseRowCheck):
             DataFrame: A new DataFrame with an additional boolean column where True indicates failure.
 
         Raises:
-            MissingColumnError: If either column is not found in the DataFrame.
+            MissingColumnError: If column is not found in the DataFrame.
+            InvalidSQLExpressionError: If the limit expression is invalid or cannot be evaluated.
         """
         if self.column not in df.columns:
             raise MissingColumnError(self.column, df.columns)
@@ -138,12 +139,12 @@ class ColumnLessThanCheckConfig(BaseRowCheckConfig):
     check_class = ColumnLessThanCheck
 
     column: str = Field(
-        ..., description="The column expected to contain smaller (or equal) values.", alias="smaller-column"
+        ..., description="The column expected to contain smaller (or equal) values.", alias="column"
     )
     limit: str = Field(
         ...,
         description="The column or a Spark SQL expression expected to contain greater values.",
-        alias="greater-column",
+        alias="limit",
     )
     inclusive: bool = Field(
         False, description="If True, allows equality (<=). Otherwise requires strict inequality (<)."

--- a/sparkdq/checks/row_level/columns_comparison_checks/column_less_than.py
+++ b/sparkdq/checks/row_level/columns_comparison_checks/column_less_than.py
@@ -78,7 +78,7 @@ class ColumnLessThanCheck(BaseRowCheck):
         try:
             df.limit(0).select(F.expr(self.limit).alias("_validation_limit"))
         except Exception as e:
-            raise InvalidSQLExpressionError(self.limit, e)
+            raise InvalidSQLExpressionError(self.limit, str(e))
 
         smaller = F.col(self.column)
         greater = F.expr(self.limit)

--- a/sparkdq/exceptions.py
+++ b/sparkdq/exceptions.py
@@ -103,3 +103,38 @@ class MissingCheckTypeError(CheckConfigurationError):
             "Missing 'check' field in check configuration. "
             "Each check config must include a 'check' key to identify the check type."
         )
+
+
+class InvalidSQLExpressionError(RuntimeCheckConfigurationError):
+    """
+    Raised when a SQL expression is syntactically or semantically invalid.
+
+    This error indicates that the provided SQL expression cannot be parsed
+    or executed by PySpark, typically due to syntax errors, invalid function
+    calls, or other structural issues that prevent the expression from being
+    evaluated.
+
+    Examples include:
+        - Malformed syntax: "age + "
+        - Unbalanced parentheses: "upper(name"
+        - Invalid function calls: "invalid_function(column)"
+        - Dangerous operations: "DROP TABLE users"
+
+    This exception is used to ensure consistent error handling for SQL
+    expression validation in data quality checks.
+    """
+
+    def __init__(self, expression: str, error_message: str):
+        """
+        Initialize the exception with the invalid expression and error details.
+
+        Args:
+            expression (str): The SQL expression that failed validation.
+            error_message (str): Detailed description of why the expression is invalid.
+
+        The message will include both the expression and error details to aid
+        debugging and error reporting.
+        """
+        super().__init__(f"Invalid SQL expression '{expression}':\n{error_message}")
+        self.expression = expression
+        self.error_message = error_message


### PR DESCRIPTION
## 📌 What does this PR do?
Updates check [ColumnLessThanCheck](https://github.com/sparkdq-community/sparkdq/blob/2298fd7643e0a246ad91d6b3babe20e8510bc364/sparkdq/checks/row_level/columns_comparison_checks/column_less_than.py#L12) to support more flexible validation scenarios beyond simple column-to-column comparisons

**Before:** The class only supported checking if one column is less than another column:

- Required two specific columns: smaller_column and greater_column
- Limited to direct column comparisons only

**After:** The class now supports checking a column against configurable limits:

- Check a single column against an upper limit
- The limit can be either: Another column name or A SQL expression (literal values, calculations, functions, etc.)
- Maintains backward compatibility with existing column-to-column checks

**Use cases enabled:**

- Validate column against static values: `age < 65`
- Validate against calculated limits: `salary < (base_salary * 1.5)`
- Validate against dynamic expressions: `order_date < CURRENT_DATE()`
- Continue supporting column comparisons: `start_date < end_date`

---

## 🧪 Checklist

- [x] I followed the project's coding style.
- [x] I added new unit tests for the changes (if applicable).
- [x] All existing and new tests pass (`pytest --cov=sparkdq`).
- [x] I updated the documentation (if applicable).
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

---

## 🔎 Related Issues
---

## 📂 Additional Notes

If this enhancement can be merged, I'll create another MR for class **ColumnGreaterThanCheck**

---
