### PR TITLE
docs: overhaul documentation and site, batch observable aggregate checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,15 @@ jobs:
   lint:
     name: "Lint"
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/astral-sh/uv:python3.13-trixie
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
 
       - name: Install lint dependencies
         run: uv sync --group lint
@@ -84,11 +88,15 @@ jobs:
     name: "Documentation"
     needs: lint
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/astral-sh/uv:python3.13-trixie
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
 
       - name: Install docs dependencies
         run: uv sync --group docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,12 +9,18 @@ env:
   UV_LINK_MODE: "copy"
   UV_FROZEN: "1"
 
+# Least privilege by default; the release job elevates as needed.
 permissions:
-  contents: write
+  contents: read
+
+# Cancel superseded runs on the same ref to save minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
-    name: "🔍 Code Linting"
+    name: "Lint"
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/astral-sh/uv:python3.13-trixie
@@ -35,23 +41,30 @@ jobs:
         run: uv run mypy .
 
   tests:
-    name: "🔍 Run Tests"
+    name: "Tests (py${{ matrix.python-version }})"
     needs: lint
-
     runs-on: ubuntu-latest
-    container:
-      image: jupyter/pyspark-notebook
-      options: --user root
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - name: Install git and gpg (needed for checkout and codecov validation)
-        run: |
-          apt-get update && apt-get install -y git gpg
-
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        run: pip install uv
+      # PySpark needs a JRE; pin it for reproducibility.
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
 
       - name: Install test dependencies
         run: uv sync --group test
@@ -59,16 +72,34 @@ jobs:
       - name: Run unit tests
         run: uv run pytest --cov -v --cov-report=term --cov-report=xml
 
+      # Upload coverage once, from the primary version.
       - name: Upload coverage reports to Codecov
+        if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: sparkdq-community/sparkdq
 
+  docs:
+    name: "Documentation"
+    needs: lint
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/astral-sh/uv:python3.13-trixie
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install docs dependencies
+        run: uv sync --group docs
+
+      - name: Build documentation (strict)
+        run: uv run mkdocs build --strict
+
   release:
-    name: "🚀 Publish Package"
+    name: "Release"
     if: github.ref == 'refs/heads/main'
-    needs: tests
+    needs: [tests, docs]
 
     runs-on: ubuntu-latest
     container:
@@ -109,13 +140,16 @@ jobs:
           uv publish
 
   pages:
-    name: "🚀 Publish Documentation to GitHub Pages"
+    name: "Deploy Docs"
     if: github.ref == 'refs/heads/main'
     needs: release
 
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/astral-sh/uv:python3.13-trixie
+
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Prettier reformats MkDocs Material admonitions (`!!!`) by stripping the
+# 4-space body indentation they require, which breaks their rendering.
+# Exclude the docs so Material-specific Markdown is left intact.
+docs/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 # SparkDQ — Data Quality Validation for Apache Spark
 
-**SparkDQ** is a lightweight data quality framework built natively for PySpark — no JVM bridge like [PyDeequ](https://github.com/awslabs/python-deequ), no complexity overhead like [Great Expectations](https://github.com/great-expectations/great_expectations), and no platform lock-in like [Databricks dqx](https://github.com/databrickslabs/dqx). Define checks declaratively via YAML/JSON or through a type-safe Python API, validate at row and aggregate level in a single pass, and extend the framework via a plugin system without touching the core.
+**SparkDQ** is a lightweight data quality framework built natively for PySpark. You describe what valid data looks like — declaratively via YAML/JSON or through a type-safe Python API — and it validates your DataFrame at row and aggregate level in a single pass.
+
+Its defining trait is what it leaves out. SparkDQ is intentionally small in scope and low in complexity — a focused set of checks and a single-pass engine, with no metadata store, orchestration layer, or profiling engine to operate. For most pipelines, that is exactly enough, and the reduced complexity is a feature in itself. That focus is what sets it apart: no JVM bridge like [PyDeequ](https://github.com/awslabs/python-deequ), no complexity overhead like [Great Expectations](https://github.com/great-expectations/great_expectations), and no platform lock-in like [Databricks dqx](https://github.com/databrickslabs/dqx).
 
 **One dependency. No wrappers. No bloat.**
 
@@ -103,6 +105,8 @@ pip install sparkdq
 The framework supports Python 3.11+ and is fully tested with PySpark 3.5.x. SparkDQ will automatically check for PySpark availability on import and provide clear error messages if PySpark is missing in your environment.
 
 ## Why SparkDQ?
+
+- **Small on purpose**: A focused scope and low complexity — quick to learn, hard to misconfigure, and enough for most pipelines
 
 - **Extensible by design**: Add custom checks via a simple plugin system — no changes to the core required
 

--- a/docs/architecture/core_abstractions.md
+++ b/docs/architecture/core_abstractions.md
@@ -1,0 +1,153 @@
+# Core Abstractions
+
+The core abstractions define the contracts every check implementation must
+honour. They live in `sparkdq/core/` and are deliberately minimal: a check is an
+object with an identity, a severity, and one of two evaluation shapes — per-row
+or per-dataset. Everything else in the framework is built on top of these few
+types.
+
+## The shared root: `BaseCheck`
+
+Every check descends from `BaseCheck` (`core/base_check.py`), which contributes
+the two things all checks have in common: a `check_id` and a `severity`
+(`Severity.CRITICAL` by default). On top of that it provides the reporting
+machinery — `name` returns the implementing class name (used as the `check`
+field in every result), and `description()` produces the serializable metadata
+record `{check, check-id, severity, parameters}`.
+
+The `parameters` in that record are not hand-maintained. `_parameters()`
+inspects the subclass constructor signature and reads the matching instance
+attributes, which has one practical consequence for implementers: **every
+constructor argument that should appear in reports must be stored as an instance
+attribute of the same name**, since `check_id`, `severity`, and `columns` are
+excluded by design.
+
+The other rule to remember is that `check_id` must be **unique within a
+`CheckSet`**. Row checks use it verbatim as a DataFrame column name (see below),
+so a duplicate silently overwrites an earlier check's result column. `BaseCheck`
+itself is never subclassed directly — checks extend one of the two specializations
+that follow.
+
+## Two evaluation shapes
+
+The split between row-level and dataset-level checks is the central distinction
+in the framework, and it runs all the way through to the [execution
+flow](execution_flow.md) and [output model](output_model.md).
+
+### `BaseRowCheck` — one verdict per row
+
+A row check implements `validate(df: DataFrame) -> DataFrame`. It must return the
+input unchanged except for a single appended boolean column named after its
+`check_id`; the helper `with_check_result_column(df, condition)` enforces that
+convention. The column's polarity is inverted on purpose — `True` marks a
+**failed** row, `False` a passing one — so the engine can treat any `True` as a
+violation without knowing anything check-specific.
+
+Because row checks are composed into one query plan, `validate()` must stay a
+pure, lazy transformation: it adds a column and nothing more. Triggering a Spark
+action (`count`, `collect`, `first`, …) inside a row check would force a scan per
+check and defeat single-pass execution — that work belongs to the engine.
+
+### `BaseAggregateCheck` — one verdict per dataset
+
+An aggregate check evaluates a global property (row counts, uniqueness ratios,
+schema conformance, …) and yields exactly one outcome per run, regardless of row
+count. It implements `_evaluate_logic(df) -> AggregateEvaluationResult`; callers
+invoke `evaluate(df)`, which wraps that raw outcome in a full
+`AggregateCheckResult` (adding `check`, `check_id`, `severity`, and `parameters`).
+
+One detail is worth calling out because it looks like an oversight but isn't: on
+`BaseAggregateCheck`, `_evaluate_logic()` _raises_ `NotImplementedError` instead
+of being marked `@abstractmethod`. That is what lets the observable subclass
+below provide a working default, while a classic aggregate check that forgets to
+override it still fails loudly.
+
+## `ObservableAggregateCheck` — aggregates that batch together
+
+Most aggregate checks can express their logic as Spark aggregation _expressions_
+rather than as imperative code. Those extend `ObservableAggregateCheck`
+(`core/observable_check.py`), and doing so is what enables single-pass
+aggregation — the reasoning is in
+[Design Decisions → Observable aggregation](decisions/observable_aggregation.md).
+
+Such a check implements two methods:
+
+- `aggregations() -> dict[str, Column]` — the metric expressions it needs.
+- `_evaluate_from_agg_results(results: dict[str, Any])` — the verdict, computed
+  from the already-resolved metric values.
+
+Metric keys only need to be unique _within a single check_; the runner
+namespaces them per instance, so two checks may both use `"count"` without
+colliding. The class also ships a working `_evaluate_logic()` that runs the
+aggregations in its own `df.agg()` — the engine bypasses this and feeds each
+check batched results directly, but the standalone path keeps a check runnable in
+isolation, which is convenient in unit tests. Checks that genuinely cannot be
+reduced to a single `agg()` (needing `groupBy`, `join`, or `distinct`) simply
+stay on plain `BaseAggregateCheck` and are executed individually.
+
+## `IntegrityCheckMixin` — validating across datasets
+
+Some checks — foreign keys, referential integrity, cross-dataset consistency —
+need a _second_ dataset to compare against. `IntegrityCheckMixin` supplies that
+capability as an opt-in: the engine calls `inject_reference_datasets(datasets)`
+during preparation, and the check later resolves a dataset by name with
+`get_reference_df(name)`, which raises `MissingReferenceDatasetError` if the name
+was never supplied. Because injection happens per run, a check must resolve
+references inside `validate()` / `_evaluate_logic()` rather than in its
+constructor, where the datasets are not yet available.
+
+## `Severity` — how failures are handled
+
+Severity is a two-valued enum (`core/severity.py`). Which severities actually
+fail a row is governed by the engine's `fail_levels` (default `[CRITICAL]`): a
+failure whose severity is in `fail_levels` marks rows invalid
+(`_dq_passed = False`) and, for aggregates, can fail the whole batch, while any
+other failure is recorded in `_dq_errors` but leaves `_dq_passed` untouched. With
+the default configuration this means `CRITICAL` fails and `WARNING` only warns.
+When configs arrive from YAML or JSON, `normalize_severity()` accepts either an
+enum or a case-insensitive string and raises `InvalidSeverityLevelError` on
+anything else.
+
+## From definition to instance: the configuration layer
+
+A check is _defined_ through a paired **Config class** — a Pydantic model
+inheriting from `BaseRowCheckConfig` or `BaseAggregateCheckConfig`
+(`core/base_config.py`). It declares a `check_class` ClassVar pointing at the
+implementation plus one typed field per constructor parameter; `to_check()` then
+builds a validated instance from those fields. Thanks to `populate_by_name`, the
+same class serves both Python callers (`check_id`) and YAML callers
+(`check-id`).
+
+The payoff is that misconfiguration is caught early. The `check_class` ↔
+base-class binding is verified at **class-definition time** via
+`__init_subclass__`: a row config pointing at an aggregate check — or one missing
+`check_class` entirely — raises `TypeError` the moment the module is imported,
+long before any data is touched.
+
+## From name to class: the plugin layer
+
+Declarative configs refer to checks by string (`"null-check"`), so something has
+to map those names to classes. That is the `CheckConfigRegistry`
+(`plugin/check_config_registry.py`), a process-wide `name → config class` table.
+The `@register_check_config(check_name="…")` decorator populates it as an import
+side effect; registering a name twice raises `ValueError`, which turns accidental
+clashes into loud import-time errors rather than silent shadowing.
+
+The `CheckFactory` (`plugin/check_factory.py`) is the consumer. Given a raw dict
+it requires a `check` key (otherwise `MissingCheckTypeError`), then normalizes any
+`severity` _without mutating the caller's dict_ — an invalid severity string
+fails here with `InvalidSeverityLevelError`, before Pydantic runs. It then looks
+up the config class and validates the remaining parameters through Pydantic,
+which raises a `ValidationError` on bad input, and returns the built check. Its
+`from_list()` entry point first calls `load_config_module("sparkdq.checks")` so
+every built-in is registered before resolution begins.
+
+## Bringing it together: `CheckSet`
+
+`CheckSet` (`management/check_set.py`) is the user-facing container and the
+single source of truth for one validation run. Checks go in either as typed
+config objects via the chainable `add_check()`, or as raw dicts via
+`add_checks_from_dicts()` (which routes through the factory above). Internally it
+keeps the row and aggregate checks separable, exposing `get_row_checks()` and
+`get_aggregate_checks()` — the very split that drives the two-phase
+[execution flow](execution_flow.md).

--- a/docs/architecture/decisions/dataframe_annotations.md
+++ b/docs/architecture/decisions/dataframe_annotations.md
@@ -1,0 +1,51 @@
+# Metadata Columns on the DataFrame
+
+**Decision.** Validation results are written back onto the DataFrame itself as
+`_dq_*` metadata columns (`_dq_passed` and `_dq_errors`), rather than returned as
+a separate, detached report object. Failed aggregate checks are folded into the
+same `_dq_errors` array, so a single column carries every violation.
+
+## Context
+
+Once checks have run, a caller almost always wants to _act_ on the outcome:
+route the clean rows onward, quarantine the bad ones, log the warnings. If the
+verdict lived in a separate report keyed by some row identifier, the caller would
+have to join that report back to the data to act on it — and that assumes a
+stable identifier exists, which for arbitrary input DataFrames it may not.
+
+Keeping the verdict physically attached to the row it describes removes that
+whole class of problem.
+
+## Benefits
+
+- **Every row carries its own verdict.** `_dq_passed` says whether the row passed;
+  `_dq_errors` lists exactly which checks fired and at what severity. The "which
+  rows failed, and why" question is answered by looking at the row — never by
+  reconstructing a correlation.
+- **Result views are trivial filters.** `pass_df()`, `fail_df()`, and `warn_df()`
+  are just predicates over the annotated DataFrame. There is no bookkeeping to
+  keep a side report in sync with the data, because there is no side report.
+- **Immediate, natural downstream use.** The annotated DataFrame drops straight
+  into the rest of a Spark pipeline. Writing failures to a quarantine table is a
+  `fail_df().write` away, metadata included — no extra join, no extra stage.
+- **Clean round-trip for the happy path.** `pass_df()` selects exactly the
+  original input columns, so the passing subset is schema-compatible with the
+  source and can be written back without stripping the `_dq_*` columns by hand.
+- **Auditable by construction.** `fail_df()` and `warn_df()` carry a single
+  `_dq_validation_ts` fixed at result-construction time, so every row from one
+  run shares an identical, traceable timestamp.
+
+## Trade-offs
+
+The output DataFrame is wider than the input while the `_dq_*` columns are
+present, and the result views are Spark _actions_ — `summary()` performs several
+`count()`s, and each `*_df()` re-scans the plan. The mitigation is conventional
+Spark hygiene: cache the annotated DataFrame (`result.df.cache()`) when several
+views will be derived from it. This is a familiar cost with a familiar remedy,
+and it is far cheaper than the join-back a detached report would require on every
+access.
+
+## Where to look
+
+- `engine/batch/validation_result.py` — `BatchValidationResult` and its views.
+- [Output Model](../output_model.md).

--- a/docs/architecture/decisions/declarative_config.md
+++ b/docs/architecture/decisions/declarative_config.md
@@ -1,0 +1,55 @@
+# Declarative Configuration Layer
+
+**Decision.** Every check is _defined_ through a Pydantic **Config class** rather
+than by instantiating check objects directly. A config can be constructed from
+typed Python or built from a plain dictionary loaded from YAML or JSON. The
+config validates its parameters and, via `to_check()`, produces the runnable
+check instance.
+
+## Context
+
+A data quality rule ("this column must not be null", "the row count must sit
+between 1,000 and 10,000") is a piece of _configuration_, not a piece of program
+logic. The people who know those rules — data owners, analysts, domain experts —
+are not always the people who maintain the pipeline code. And even when they are,
+a rule that lives as a hand-instantiated Python object is hard to review,
+version, or move between environments.
+
+Separating the _definition_ of a check from its _execution_ addresses this. The
+config class is the definition; the check instance is the execution.
+
+## Benefits
+
+- **Rules can live outside the code.** Because a config is just data, checks can
+  be authored and maintained in YAML or JSON — in a separate repository, a config
+  store, or a database — and loaded at runtime. The pipeline no longer has to
+  change when a rule changes.
+- **Errors surface early and cheaply.** Pydantic validates every parameter the
+  moment the config is built, _before_ a Spark job is ever submitted. A typo in a
+  threshold or a missing required field fails immediately with a precise message,
+  instead of after minutes of cluster time.
+- **Definitions are reviewable and portable.** Plain-data definitions can be
+  diffed in a pull request, versioned in Git, and promoted from staging to
+  production unchanged. The rule set becomes an auditable artifact in its own
+  right.
+- **Type safety without giving up flexibility.** Typed config classes give IDE
+  autocompletion and `mypy` coverage for Python authors, while
+  `populate_by_name` lets the _same_ class accept kebab-case keys
+  (`check-id`) from YAML. One definition serves both audiences.
+- **Misconfiguration is caught at import.** The `check_class` ↔ base-class
+  binding is enforced in `__init_subclass__`, so a config wired to the wrong kind
+  of check raises `TypeError` when its module loads — not mid-run.
+
+## Trade-offs
+
+Each check needs a paired config class, which is a small, repetitive amount of
+boilerplate. This is a deliberate exchange: a few extra lines per check buys
+validation, portability, tooling, and a single declarative surface. In practice
+the config class is also the natural home for the check's documented parameter
+schema, so the boilerplate does double duty.
+
+## Where to look
+
+- `core/base_config.py` — `BaseCheckConfig`, `BaseRowCheckConfig`,
+  `BaseAggregateCheckConfig`.
+- [Core Abstractions → configuration layer](../core_abstractions.md#from-definition-to-instance-the-configuration-layer).

--- a/docs/architecture/decisions/observable_aggregation.md
+++ b/docs/architecture/decisions/observable_aggregation.md
@@ -1,0 +1,58 @@
+# Observable Single-Pass Aggregation
+
+**Decision.** Aggregate checks that can express their logic as Spark aggregation
+expressions extend `ObservableAggregateCheck` and declare their needs via
+`aggregations()`. The `BatchCheckRunner` collects the expressions from _all_ such
+checks and executes them in a **single** `df.agg()` call, then dispatches the
+resolved values back to each check's `_evaluate_from_agg_results()`.
+
+## Context
+
+The obvious way to run aggregate checks is one at a time: ask each check to
+evaluate itself against the DataFrame. It works, and it is easy to reason about —
+but every self-contained evaluation is its own Spark action, and every action
+triggers a scan (and sometimes a shuffle) of the data.
+
+On a small test dataset the difference is invisible. On a production-sized table
+it is not: with the naive approach, N aggregate checks trigger N independent full
+scans of the same data. The observable pattern collapses those into one, which is
+the motivation for the design.
+
+## Benefits
+
+- **Many checks, one pass over the data.** All observable checks contribute their
+  metric expressions to a single `df.agg()`. Ten row-count-and-completeness style
+  checks collapse from ten scans into one. The saving grows linearly with the
+  number of aggregate checks.
+- **Lower cost on managed compute.** Fewer full-table scans mean less cluster
+  time, which on managed platforms such as Databricks maps directly to cost. The
+  optimization pays off exactly where it matters most — large datasets in
+  production.
+- **The optimization is transparent to authors.** A check author only declares
+  _what_ to measure (`aggregations()`) and _how to judge it_
+  (`_evaluate_from_agg_results()`). The batching is entirely the runner's
+  concern; the author never writes a `df.agg()` call and never thinks about
+  Spark actions.
+- **Safe composition.** Metric keys only need to be unique within a single check;
+  the runner namespaces them per instance, so unrelated checks can freely reuse
+  common names like `"count"` without colliding.
+- **Still runnable in isolation.** The base class ships a working
+  `_evaluate_logic()` that runs the aggregations in its own `df.agg()`. The engine
+  bypasses it for batching, but the standalone path keeps a single check testable
+  on its own — the optimization does not sacrifice unit-test ergonomics.
+
+## Trade-offs
+
+Not every aggregate check _can_ be reduced to a single `agg()`. Anything needing
+`groupBy`, `join`, or `distinct` cannot participate, and those checks stay on
+plain `BaseAggregateCheck` and are evaluated individually (the "classic" path).
+The framework accepts this two-track model rather than forcing an awkward fit:
+observable is the fast common case, classic is the correct fallback, and result
+ordering is preserved regardless of which path a check takes.
+
+## Where to look
+
+- `core/observable_check.py` — the base class and its contract.
+- `engine/batch/check_runner.py` — `_run_observable_checks()`, the batched
+  `df.agg()`.
+- [Core Abstractions → ObservableAggregateCheck](../core_abstractions.md#observableaggregatecheck-aggregates-that-batch-together).

--- a/docs/architecture/decisions/plugin_system.md
+++ b/docs/architecture/decisions/plugin_system.md
@@ -1,0 +1,59 @@
+# Registry + Factory + Decorator Plugin System
+
+**Decision.** Check names — the strings used in declarative configs, such as
+`"null-check"` — are mapped to config classes through a central
+`CheckConfigRegistry`. The registry is populated by the
+`@register_check_config` decorator and consumed by a `CheckFactory`. There is no
+central `if/elif` dispatch and no hand-maintained list of imports.
+
+## Context
+
+Declarative configs refer to checks by string. Something has to turn
+`"null-check"` into the concrete class that knows how to validate the
+parameters and build the check. The naive approaches all age badly: a giant
+`if/elif` block becomes a merge-conflict magnet and couples every check to a
+central switch, while a hand-maintained import list silently drifts out of date
+whenever someone adds a check and forgets to register it.
+
+The framework also has an explicit goal of being extensible by _third parties_ —
+users should be able to ship their own checks without forking or patching the
+core.
+
+## Benefits
+
+- **Extensible without touching the core.** A new check is added purely by
+  defining its class and decorating its config with
+  `@register_check_config("my-check")`. No core file is edited, no central
+  registry is hand-updated — a direct application of the open/closed principle.
+  Third-party checks are first-class citizens, indistinguishable from built-ins
+  at resolution time.
+- **Name and implementation are decoupled.** The public contract is the string
+  name in YAML. The implementing class can be renamed, moved, or refactored
+  freely without breaking a single existing config — the registry is the only
+  thing that has to agree on the name.
+- **Registration lives with the definition.** The decorator sits on the config
+  class itself, so the fact _that_ a check is registered and _under what name_ is
+  visible right where the check is defined, not in a distant lookup table that
+  has to be kept in sync.
+- **Clashes fail loudly.** Registering a name twice raises `ValueError` at import
+  time. An accidental duplicate is caught immediately instead of silently
+  shadowing an existing check and changing behavior at runtime.
+- **A single, testable resolution path.** All name resolution flows through
+  `CheckConfigRegistry.get()` and `CheckFactory`, giving one place to reason
+  about — and test — how a string becomes a running check.
+
+## Trade-offs
+
+Registration is a side effect of importing the module that defines the check.
+Built-ins are handled transparently — `CheckFactory.from_list()` calls
+`load_config_module("sparkdq.checks")` first — but a _custom_ check's module must
+be imported (directly, via `load_config_module`, or implicitly by adding the
+config to a `CheckSet`) before its name will resolve. This import-to-register
+coupling is the standard cost of decorator-based plugin systems, and it is
+predictable once understood.
+
+## Where to look
+
+- `plugin/check_config_registry.py` — the registry and the decorator.
+- `plugin/check_factory.py` — dict-to-check resolution.
+- [Custom Checks](../../custom_checks/overview.md) — the author-facing walkthrough.

--- a/docs/architecture/decisions/row_vs_aggregate.md
+++ b/docs/architecture/decisions/row_vs_aggregate.md
@@ -1,0 +1,54 @@
+# Row-Level vs. Aggregate-Level Separation
+
+**Decision.** Row checks and aggregate checks are kept strictly apart: separate
+base classes (`BaseRowCheck`, `BaseAggregateCheck`), separate result models, and
+separate execution paths inside `BatchCheckRunner`.
+
+## Context
+
+There is a tempting simplification available: model every check as "a thing that
+looks at data and returns a verdict", and unify them behind one interface. But
+the two kinds of verdict are not the same shape at all. "Is _this row's_ email
+null?" produces one answer per row. "Does _the dataset_ have between 1,000 and
+10,000 rows?" produces exactly one answer for the whole dataset. Forcing both
+through a single abstraction means every consumer downstream has to keep asking
+"but which kind is this really?" — and the abstraction leaks anyway.
+
+The two kinds also _execute_ differently. A per-row verdict is naturally a column
+you append; a dataset-wide verdict is naturally a Spark aggregation. Those are
+different mechanisms with different performance characteristics.
+
+## Benefits
+
+- **The model matches the domain.** Two genuinely different concepts are
+  represented as two types. A `BaseRowCheck` returns an annotated DataFrame; a
+  `BaseAggregateCheck` returns an `AggregateCheckResult`. Neither has to pretend
+  to be the other, and neither carries fields that only make sense for the other.
+- **Each path can be optimized independently.** Row checks compose as lazy column
+  transformations and never trigger an action on their own. Aggregate checks run
+  as Spark aggregations — and because they are a distinct group, the runner can
+  apply the [single-pass batching](observable_aggregation.md) optimization to
+  them without that logic bleeding into row-check handling.
+- **Outputs stay clean and purpose-fit.** Row results flow into per-row
+  metadata columns and the `pass_df()`/`fail_df()`/`warn_df()` views; aggregate
+  results flow into a separate ordered list for reporting. Consumers pick exactly
+  the shape they need instead of unpacking a union type.
+- **Clearer extension surface.** An author writing a custom check chooses a base
+  class up front, and the base makes the required method obvious (`validate()`
+  vs. `_evaluate_logic()`). The type system guides the implementation rather than
+  leaving it to convention.
+
+## Trade-offs
+
+The runner has to branch on check type and maintain two code paths, and the
+framework carries two base classes instead of one. This is accepted precisely
+because the alternative — a single abstraction — pushes that same branching onto
+_every_ consumer of a check result, where it would be repeated and error-prone.
+Concentrating the split in one place (the runner and the base classes) is the
+cheaper of the two.
+
+## Where to look
+
+- `core/base_check.py` — the two base classes.
+- `engine/batch/check_runner.py` — the two-phase execution.
+- [Execution Flow](../execution_flow.md).

--- a/docs/architecture/design_decisions.md
+++ b/docs/architecture/design_decisions.md
@@ -1,0 +1,50 @@
+# Design Decisions
+
+This section records the _why_ behind SparkDQ's architecture — the reasoning,
+the benefits, and the trade-offs. The _what_ and _how_ are covered in the rest of
+the [Architecture](overview.md) section; these pages exist so that contributors
+and users can understand the intent behind the structure and avoid re-litigating
+settled choices.
+
+Each decision has its own page, following the same shape: the **decision**, the
+**context** that motivated it, the **benefits** it delivers, and the
+**trade-offs** it accepts.
+
+## Guiding principles
+
+A few principles run through all of the individual decisions below:
+
+- **Rule-based, not statistical.** SparkDQ validates data against _explicit_
+  rules. Automatic data profiling and ML-based anomaly detection are a deliberate
+  **non-goal** — the framework does exactly what you tell it to check, and nothing
+  implicit. Behavior is predictable and every result is auditable.
+- **Minimal dependencies.** The core depends only on Pydantic. PySpark is
+  expected to come from the runtime platform (e.g. Databricks) rather than being
+  bundled, keeping the footprint small and avoiding version conflicts with the
+  host environment.
+- **Batch first, streaming later.** The current engine targets batch validation.
+  The engine layer is abstracted behind `BaseDQEngine` specifically so a
+  streaming engine can be added later without reworking the check catalogue or
+  the configuration system.
+
+## The decisions
+
+| Decision                                                                   | In one line                                                                                  |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [Declarative configuration layer](decisions/declarative_config.md)         | Checks are defined as validated Pydantic data, authorable from YAML/JSON.                    |
+| [Registry + Factory + Decorator plugin system](decisions/plugin_system.md) | Check names resolve to classes through a registry, so the core never changes to add a check. |
+| [Row-level vs. aggregate-level separation](decisions/row_vs_aggregate.md)  | Two genuinely different verdict shapes get two base classes and two execution paths.         |
+| [Observable single-pass aggregation](decisions/observable_aggregation.md)  | All observable aggregate checks run in one `df.agg()` to minimize scans and cost.            |
+| [Metadata columns on the DataFrame](decisions/dataframe_annotations.md)    | Verdicts are attached to the rows themselves, not returned as a detached report.             |
+
+## At a glance
+
+| Decision                           | Primary driver                                                              |
+| ---------------------------------- | --------------------------------------------------------------------------- |
+| Declarative Pydantic configs       | External YAML/JSON authoring, early validation, portability, typing         |
+| Registry + Factory + Decorator     | Extensibility without core changes; name resolution for declarative configs |
+| Row vs. aggregate separation       | Different semantics and different execution strategies                      |
+| Observable single-pass aggregation | Minimize Spark actions / cost at scale (N scans collapse to one)            |
+| `_dq_*` columns on the DataFrame   | Row-level traceability and direct downstream routing                        |
+| Rule-based only                    | Predictable, auditable behavior (non-goal: profiling/ML anomaly detection)  |
+| Minimal deps / batch-first         | Small footprint; room to add streaming behind `BaseDQEngine`                |

--- a/docs/architecture/execution_flow.md
+++ b/docs/architecture/execution_flow.md
@@ -1,0 +1,79 @@
+# Execution Flow
+
+A batch validation is a two-phase process over a single logical pass of the
+data: row-level checks are composed as lazy column transformations, and
+aggregate checks are collapsed into as few Spark actions as possible.
+
+`BatchDQEngine` (`engine/batch/dq_engine.py`) is the entry point. It is
+constructed with a `CheckSet` and `fail_levels` (default `[Severity.CRITICAL]`)
+and delegates to `BatchCheckRunner`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant Engine as BatchDQEngine
+    participant Runner as BatchCheckRunner
+    participant Spark
+
+    User->>Engine: run_batch(df, reference_datasets?)
+    Engine->>Runner: run(df, checks, reference_datasets)
+    Runner->>Runner: inject reference datasets (integrity checks)
+    Runner->>Runner: split into row vs. aggregate checks
+    loop each row check
+        Runner->>Spark: df = check.validate(df)  (lazy)
+    end
+    Runner->>Runner: build _dq_passed and _dq_errors columns
+    Runner->>Spark: single df.agg() for observable checks
+    Spark-->>Runner: aggregated metrics
+    Runner->>Runner: evaluate classic aggregate checks
+    Runner->>Runner: attach aggregate errors / fail batch if fail-level
+    Runner-->>Engine: (annotated df, aggregate results)
+    Engine-->>User: BatchValidationResult
+```
+
+## Steps in detail
+
+`BatchCheckRunner.run()` (`engine/batch/check_runner.py`):
+
+1. **Inject reference datasets.** Every check implementing `IntegrityCheckMixin`
+   receives the named reference DataFrames. Checks without the mixin are skipped.
+2. **Partition checks** into row-level (`BaseRowCheck`) and aggregate-level
+   (`BaseAggregateCheck`).
+3. **Apply row checks** in sequence. Each `validate()` appends its boolean
+   column. For every check the runner records a `struct(check, check-id,
+severity)` and, if the check's severity is in `fail_levels`, a fail flag.
+4. **Compute `_dq_passed`.** The fail flags (checks whose severity is in
+   `fail_levels`) are OR-ed and negated: a row passes iff none of its
+   fail-level checks fired. With no such checks, all rows pass.
+5. **Build `_dq_errors`.** The per-check error structs are collected into an
+   array and filtered to the entries that actually fired for each row, so a
+   passing row carries an empty array rather than a list of nulls.
+6. **Evaluate aggregate checks.** Observable checks are batched into a **single**
+   `df.agg()` call; classic checks are evaluated individually. Results are
+   re-ordered to match the original declaration order.
+7. **Attach aggregate outcomes.** Failed aggregates are concatenated onto
+   `_dq_errors`. If any failed aggregate has a severity in `fail_levels`, **every
+   row** is set to `_dq_passed = False` — a dataset-level breach fails the batch
+   as a whole, because the offending rows cannot be localized.
+
+The runner returns the annotated DataFrame and the ordered list of
+`AggregateCheckResult`; the engine wraps both in a `BatchValidationResult`.
+
+## Semantics worth noting
+
+- **Order independence for row checks.** Row checks only add columns, so their
+  relative order does not change the outcome. Aggregate results, by contrast, are
+  explicitly restored to declaration order for stable reporting.
+- **Warnings never fail rows (by default).** Under the default
+  `fail_levels=[CRITICAL]`, a `WARNING` check contributes to `_dq_errors` but is
+  never added to the fail flags, so it cannot flip `_dq_passed`. This is what
+  makes the `warn_df()` view (passed rows carrying warnings) meaningful. A caller
+  that puts `WARNING` in `fail_levels` changes this — see the
+  [Output Model](output_model.md).
+- **Laziness, then forced aggregate actions.** Row-check composition only builds
+  up a query plan; nothing runs yet. The aggregate phase is what first forces
+  execution — the batched observable `df.agg().first()`, plus one action per
+  classic aggregate check — all against the _original_ input DataFrame. The
+  annotated DataFrame itself stays lazy until a view is materialized, so callers
+  that derive several views should cache it (`result.df.cache()`).

--- a/docs/architecture/output_model.md
+++ b/docs/architecture/output_model.md
@@ -1,0 +1,45 @@
+# Output Model
+
+SparkDQ returns results _on the data itself_. A validation run annotates the
+input DataFrame with metadata columns, and `BatchValidationResult`
+(`engine/batch/validation_result.py`) exposes filtered views derived from them.
+This keeps every verdict attached to the row it describes — no join back to the
+source is ever required to answer "which rows failed, and why".
+
+## Metadata columns
+
+| Column       | Type                                       | Meaning                                                                                                                                                                        |
+| ------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `_dq_passed` | `boolean`                                  | Row-level verdict. `False` when a check whose severity is in `fail_levels` (`CRITICAL` by default) fired, or when such an aggregate failed the batch.                          |
+| `_dq_errors` | `array<struct<check, check-id, severity>>` | Every check that fired for the row; empty array when clean. Failed **aggregate** checks are appended to this same array, so it carries both row- and dataset-level violations. |
+
+## Result views
+
+`BatchValidationResult` is a frozen dataclass carrying the annotated `df`, the
+ordered `aggregate_results`, the original `input_columns`, and a run
+`timestamp`. Its views:
+
+| View        | Rows returned                                                  | Schema                                                               |
+| ----------- | -------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `pass_df()` | `_dq_passed = True`                                            | **Original input schema** — metadata columns are dropped.            |
+| `fail_df()` | `_dq_passed = False`                                           | Input columns + `_dq_errors`, `_dq_passed`, and `_dq_validation_ts`. |
+| `warn_df()` | `_dq_passed = True` **and** ≥1 `WARNING` entry in `_dq_errors` | Input columns + `_dq_errors` + `_dq_validation_ts`.                  |
+| `summary()` | —                                                              | A `ValidationSummary` (counts + `pass_rate` + `timestamp`).          |
+
+## Notes and guarantees
+
+- **`pass_df()` round-trips cleanly.** It selects exactly `input_columns`, so the
+  passing subset is schema-compatible with the source and can be written straight
+  back to a table without dropping columns.
+- **A single validation timestamp.** `_dq_validation_ts` is taken from the
+  result's `timestamp` (fixed at result construction), not evaluated per row, so
+  all rows in one run share an identical, auditable timestamp.
+- **Warnings coexist with passing.** Because warnings never clear `_dq_passed`, a
+  row can appear in both `pass_df()` and `warn_df()`. This is intentional: route
+  it to production _and_ log the warning.
+- **Views are actions.** `summary()` performs multiple `count()` calls, and each
+  `*_df()` view re-scans the plan. If several views are needed, cache the
+  annotated DataFrame (`result.df.cache()`) before deriving them.
+- **`pass_rate` is rounded.** `summary()` reports `pass_rate` rounded to two
+  decimal places, and returns `0.0` for an empty input rather than dividing by
+  zero.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,119 @@
+# Overview
+
+SparkDQ is a declarative framework for row- and aggregate-level data quality
+validation on Apache Spark. This section documents its internal architecture for
+contributors and for users who need to understand how the framework behaves
+beneath the public API — the building blocks, the contracts between them, and
+the path a validation takes from a declarative definition to an annotated Spark
+DataFrame.
+
+This page establishes the system context and the layered model. The pages that
+follow drill into the [core abstractions](core_abstractions.md), the
+[execution flow](execution_flow.md), and the [output model](output_model.md).
+The reasoning and trade-offs behind each structural choice are collected under
+[Design Decisions](design_decisions.md).
+
+## System context
+
+SparkDQ sits inside a Spark pipeline as a library, not as a service. It takes a
+DataFrame the pipeline already holds, evaluates it against a set of checks, and
+returns the same data annotated with the outcome — with no external
+infrastructure, no network calls, and no wrapping of the surrounding job.
+
+```mermaid
+flowchart LR
+    subgraph Pipeline["Host Spark pipeline"]
+        direction LR
+        SRC[(Source<br/>DataFrame)] --> DQ
+        DQ["SparkDQ"] --> PASS[(Valid rows)]
+        DQ --> FAIL[(Quarantined rows)]
+    end
+    RULES["Check definitions<br/>(Python / YAML / JSON)"] -.-> DQ
+    REF[(Reference<br/>datasets)] -.-> DQ
+```
+
+Its runtime footprint is deliberately small. The core depends only on **Pydantic
+2.x**; PySpark (**3.5.x**, Python **≥ 3.11**) is expected to be supplied by the
+host platform — typically a managed environment such as Databricks — rather than
+bundled, which avoids version conflicts with the cluster runtime.
+
+## Design goals
+
+The architecture is shaped by a small number of goals that recur throughout the
+[design decisions](design_decisions.md):
+
+- **Declarative.** A check is data, not code. Rules can be authored in Python or
+  in YAML/JSON and validated before any Spark job runs.
+- **Extensible without forking.** New checks are added by registration, never by
+  editing the framework core.
+- **Single-pass and cost-aware.** Row checks compose into one query plan, and
+  aggregate checks are batched into as few Spark actions as possible.
+- **Traceable results.** Every verdict stays attached to the row it describes, so
+  outcomes can be routed and audited directly.
+
+## Layered model
+
+SparkDQ is organized into layers with a strict, one-directional dependency rule:
+each layer depends only on the ones beneath it. This keeps the check catalogue,
+the configuration system, and the execution engine independently evolvable — a
+new check touches only the top layers, and a change to the engine cannot ripple
+up into check definitions.
+
+```mermaid
+flowchart LR
+    U["User code /<br/>YAML / JSON"] --> C["Configuration<br/>layer"] --> P["Plugin<br/>layer"] --> M["Management<br/>layer"] --> E["Engine<br/>layer"] --> K["Core<br/>abstractions"]
+```
+
+| Layer                   | Module                     | Responsibility                                                                                                         |
+| ----------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| User code / YAML / JSON | —                          | Check definitions, reference datasets, and the DataFrame to validate.                                                  |
+| Configuration           | `sparkdq.core.base_config` | Pydantic `*Config` classes validate parameters and build check instances.                                              |
+| Plugin                  | `sparkdq.plugin`           | `CheckConfigRegistry`, `CheckFactory`, and `@register_check_config` resolve a check name to a config class to a check. |
+| Management              | `sparkdq.management`       | `CheckSet` collects and groups checks into row- and aggregate-level sets.                                              |
+| Engine                  | `sparkdq.engine`           | `BatchDQEngine` drives `BatchCheckRunner` and returns a `BatchValidationResult`.                                       |
+| Core abstractions       | `sparkdq.core`             | `BaseCheck`, `BaseRowCheck`, `BaseAggregateCheck`, `ObservableAggregateCheck`, `IntegrityCheckMixin`, `Severity`.      |
+
+## End-to-end walkthrough
+
+The layers connect into a single flow. The example below is intentionally
+minimal; each numbered step maps to one layer above.
+
+```python
+from sparkdq.checks import NullCheckConfig, RowCountMinCheckConfig
+from sparkdq.engine import BatchDQEngine
+from sparkdq.management import CheckSet
+
+# 1. Configuration — declare checks as validated config objects.
+check_set = (
+    CheckSet()
+    .add_check(NullCheckConfig(check_id="email-not-null", columns=["email"]))
+    .add_check(RowCountMinCheckConfig(check_id="min-rows", min_count=1000))
+)
+
+# 2. Engine — bind the checks to an engine and run against a DataFrame.
+result = BatchDQEngine(check_set).run_batch(df)
+
+# 3. Output — act on the annotated result.
+result.pass_df().write.saveAsTable("clean")
+result.fail_df().write.saveAsTable("quarantine")
+```
+
+1. **Configuration & plugin.** Each `*Config` validates its parameters through
+   Pydantic and builds a check instance. Had the checks been supplied as
+   dictionaries (from YAML/JSON), the plugin layer would have resolved each
+   `check` name to its config class first.
+2. **Management & engine.** `CheckSet` groups the checks; `BatchDQEngine` hands
+   them to `BatchCheckRunner`, which applies row checks as lazy column
+   transformations and batches the aggregate checks into a single `df.agg()`.
+3. **Output.** `run_batch()` returns a `BatchValidationResult` whose views —
+   `pass_df()`, `fail_df()`, `warn_df()`, `summary()` — are derived from the
+   `_dq_*` metadata columns written onto the DataFrame.
+
+## Where to go next
+
+| Page                                      | Scope                                                                                                                       |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [Core Abstractions](core_abstractions.md) | The base-class contracts and the configuration, plugin, and management layers that turn a definition into a runnable check. |
+| [Execution Flow](execution_flow.md)       | The step-by-step behaviour of `run_batch()`, with a sequence diagram.                                                       |
+| [Output Model](output_model.md)           | The `_dq_*` metadata columns and the result views built on them.                                                            |
+| [Design Decisions](design_decisions.md)   | The rationale, benefits, and trade-offs behind each structural choice.                                                      |

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -182,8 +182,48 @@
 
 .md-typeset table th:first-child,
 .md-typeset table td:first-child {
-  width: 220px;
-  min-width: 220px;
+  min-width: 120px;
+}
+
+/* ─── Console / output blocks ─────────────────────────────────────────────── */
+
+/* `text` fenced blocks are used for captured console output (e.g. df.show()).
+   Give them a terminal look so they read as output, not as source code. */
+.md-typeset .language-text {
+  position: relative;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.md-typeset .language-text > pre {
+  margin: 0;
+}
+
+.md-typeset .language-text > pre > code {
+  display: block;
+  background-color: #0f172a;
+  color: #e2e8f0;
+  border: 1px solid rgba(20, 184, 166, 0.25);
+  border-radius: 6px;
+  padding: 1.9em 1em 0.9em;
+  font-size: 0.6rem;
+  line-height: 1.5;
+}
+
+/* A small "OUTPUT" label in the top-left corner of the block. */
+.md-typeset .language-text > pre::before {
+  content: "OUTPUT";
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  padding: 0.25em 0.7em;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #5eead4;
+  background-color: rgba(20, 184, 166, 0.12);
+  border-bottom-right-radius: 6px;
 }
 
 /* ─── Admonitions ─────────────────────────────────────────────────────────── */

--- a/docs/built_in_checks/checks/columns_comparison/column_greater.md
+++ b/docs/built_in_checks/checks/columns_comparison/column_greater.md
@@ -1,13 +1,26 @@
+---
+wide: true
+---
+
 # Column Greater Than Check
 
-**Check**: `column-greater-than-check`
+**Check name**: `column-greater-than-check` · **Type**: row-level · **Config**: `ColumnGreaterThanCheckConfig`
 
-**Purpose**: Enforces that values in one column are strictly greater than (or greater than or equal to) values in another column or the result of a Spark SQL expression. Rows with null values in either operand are treated as invalid.
+Flags any record where `column` is not greater than `limit`. The `limit` can be
+another column or any Spark SQL expression, so this enforces relationships like
+`end_time > start_time` or `selling_price > cost_price * 1.2`.
 
-Use the `inclusive` flag to control boundary behavior:
+## Parameters
 
-- `inclusive: false` (default) — requires `column > limit`
-- `inclusive: true` — allows `column >= limit`
+| Parameter   | Type       | Required | Default    | Description                                                                      |
+| ----------- | ---------- | -------- | ---------- | -------------------------------------------------------------------------------- |
+| `check_id`  | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.                          |
+| `column`    | `str`      | yes      | —          | The column expected to hold the greater value.                                   |
+| `limit`     | `str`      | yes      | —          | A column name or Spark SQL expression the value must exceed (e.g. `cost * 1.2`). |
+| `inclusive` | `bool`     | no       | `False`    | If `True`, allows equality (`>=`); otherwise strict (`>`).                       |
+| `severity`  | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                             |
+
+## Usage
 
 === "Python"
 
@@ -16,19 +29,11 @@ Use the `inclusive` flag to control boundary behavior:
     from sparkdq.core import Severity
 
     ColumnGreaterThanCheckConfig(
-        check_id="dropoff-after-pickup",
-        column="dropoff_datetime",
-        limit="pickup_datetime",
+        check_id="end-after-start",
+        column="end",
+        limit="start",
         inclusive=False,
-        severity=Severity.CRITICAL
-    )
-
-    ColumnGreaterThanCheckConfig(
-        check_id="selling-price-above-cost",
-        column="selling_price",
-        limit="cost_price * 1.2",
-        inclusive=True,
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -36,25 +41,96 @@ Use the `inclusive` flag to control boundary behavior:
 
     ```yaml
     - check: column-greater-than-check
-      check-id: dropoff-after-pickup
-      column: dropoff_datetime
-      limit: pickup_datetime
+      check-id: end-after-start
+      column: end
+      limit: start
       inclusive: false
-      severity: critical
-
-    - check: column-greater-than-check
-      check-id: selling-price-above-cost
-      column: selling_price
-      limit: cost_price * 1.2
-      inclusive: true
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Enforce temporal ordering, such as ensuring dropoff time is after pickup time.
-- Validate that selling price exceeds a minimum margin above cost price.
-- Apply dynamic business rules using Spark SQL expressions as the comparison limit.
+- **`limit` is a Spark SQL expression.** It may be a bare column name (`start`)
+  or an expression (`cost_price * 1.2`, or a `CASE WHEN …`). It is evaluated per
+  row against the same DataFrame.
+- **Nulls fail.** Unlike the single-value comparison checks, a null in _either_
+  `column` or the evaluated `limit` marks the row as failed.
+- **`inclusive` defaults to `False`** (strict `>`); set `True` to allow equality.
+- **Invalid expressions raise.** A `limit` that cannot be parsed raises
+  `InvalidSQLExpressionError`; a missing `column` raises `MissingColumnError`.
+
+## Example
+
+Requiring `end > start`, both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import ColumnGreaterThanCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "start": 10, "end": 20},
+        {"id": 2, "start": 30, "end": 25},
+        {"id": 3, "start": 5, "end": None},
+    ])
+
+    check_set = CheckSet().add_check(
+        ColumnGreaterThanCheckConfig(check_id="end-after-start", column="end", limit="start")
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "start": 10, "end": 20},
+        {"id": 2, "start": 30, "end": 25},
+        {"id": 3, "start": 5, "end": None},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+The row where `end <= start` and the row with a null `end` both fail:
+
+```text
++----+---+-----+-----------------------------------------------------+----------+--------------------------+
+|end |id |start|_dq_errors                                           |_dq_passed|_dq_validation_ts         |
++----+---+-----+-----------------------------------------------------+----------+--------------------------+
+|25  |2  |30   |[{ColumnGreaterThanCheck, end-after-start, critical}]|false     |2026-01-01 00:00:00.000000|
+|NULL|3  |5    |[{ColumnGreaterThanCheck, end-after-start, critical}]|false     |2026-01-01 00:00:00.000000|
++----+---+-----+-----------------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Enforce ordering between two columns (`end_time > start_time`).
+- Require a margin over a computed value (`selling_price > cost_price * 1.2`).
+- Validate conditional thresholds via a `CASE WHEN` expression.
+
+## Related checks
+
+- [Column Less Than Check](column_less.md) — the mirror comparison (`<`).
 
 ---
 

--- a/docs/built_in_checks/checks/columns_comparison/column_less.md
+++ b/docs/built_in_checks/checks/columns_comparison/column_less.md
@@ -1,13 +1,26 @@
+---
+wide: true
+---
+
 # Column Less Than Check
 
-**Check**: `column-less-than-check`
+**Check name**: `column-less-than-check` · **Type**: row-level · **Config**: `ColumnLessThanCheckConfig`
 
-**Purpose**: Enforces that values in one column are strictly less than (or less than or equal to) values in another column or the result of a Spark SQL expression. Rows with null values in either operand are treated as invalid.
+Flags any record where `column` is not less than `limit`. The `limit` can be
+another column or any Spark SQL expression, so this enforces relationships like
+`discount < price` or `cost_price < selling_price * 0.9`.
 
-Use the `inclusive` flag to control boundary behavior:
+## Parameters
 
-- `inclusive: false` (default) — requires `column < limit`
-- `inclusive: true` — allows `column <= limit`
+| Parameter   | Type       | Required | Default    | Description                                                                           |
+| ----------- | ---------- | -------- | ---------- | ------------------------------------------------------------------------------------- |
+| `check_id`  | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.                               |
+| `column`    | `str`      | yes      | —          | The column expected to hold the smaller value.                                        |
+| `limit`     | `str`      | yes      | —          | A column name or Spark SQL expression the value must stay below (e.g. `price * 0.9`). |
+| `inclusive` | `bool`     | no       | `False`    | If `True`, allows equality (`<=`); otherwise strict (`<`).                            |
+| `severity`  | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                                  |
+
+## Usage
 
 === "Python"
 
@@ -16,19 +29,11 @@ Use the `inclusive` flag to control boundary behavior:
     from sparkdq.core import Severity
 
     ColumnLessThanCheckConfig(
-        check_id="pickup-before-dropoff",
-        column="pickup_datetime",
-        limit="dropoff_datetime",
+        check_id="cost-below-margin",
+        column="cost",
+        limit="price * 0.9",
         inclusive=False,
-        severity=Severity.CRITICAL
-    )
-
-    ColumnLessThanCheckConfig(
-        check_id="cost-below-selling-price",
-        column="cost_price",
-        limit="selling_price * 0.8",
-        inclusive=True,
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -36,25 +41,93 @@ Use the `inclusive` flag to control boundary behavior:
 
     ```yaml
     - check: column-less-than-check
-      check-id: pickup-before-dropoff
-      column: pickup_datetime
-      limit: dropoff_datetime
+      check-id: cost-below-margin
+      column: cost
+      limit: "price * 0.9"
       inclusive: false
-      severity: critical
-
-    - check: column-less-than-check
-      check-id: cost-below-selling-price
-      column: cost_price
-      limit: selling_price * 0.8
-      inclusive: true
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Enforce temporal ordering, such as ensuring pickup time is before dropoff time.
-- Validate that cost price stays within an acceptable fraction of selling price.
-- Apply dynamic business rules using Spark SQL expressions as the comparison limit.
+- **`limit` is a Spark SQL expression.** It may be a bare column name (`price`)
+  or an expression (`price * 0.9`, or a `CASE WHEN …`). It is evaluated per row
+  against the same DataFrame.
+- **Nulls fail.** A null in _either_ `column` or the evaluated `limit` marks the
+  row as failed.
+- **`inclusive` defaults to `False`** (strict `<`); set `True` to allow equality.
+- **Invalid expressions raise.** A `limit` that cannot be parsed raises
+  `InvalidSQLExpressionError`; a missing `column` raises `MissingColumnError`.
+
+## Example
+
+Requiring `cost < price * 0.9`, both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import ColumnLessThanCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "cost": 50, "price": 100},
+        {"id": 2, "cost": 95, "price": 100},
+    ])
+
+    check_set = CheckSet().add_check(
+        ColumnLessThanCheckConfig(check_id="cost-below-margin", column="cost", limit="price * 0.9")
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "cost": 50, "price": 100},
+        {"id": 2, "cost": 95, "price": 100},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the row where `cost >= price * 0.9` fails:
+
+```text
++----+---+-----+----------------------------------------------------+----------+--------------------------+
+|cost|id |price|_dq_errors                                          |_dq_passed|_dq_validation_ts         |
++----+---+-----+----------------------------------------------------+----------+--------------------------+
+|95  |2  |100  |[{ColumnLessThanCheck, cost-below-margin, critical}]|false     |2026-01-01 00:00:00.000000|
++----+---+-----+----------------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Enforce ordering between two columns (`discount < price`).
+- Require a value to stay below a computed threshold (`cost < price * 0.9`).
+- Validate conditional ceilings via a `CASE WHEN` expression.
+
+## Related checks
+
+- [Column Greater Than Check](column_greater.md) — the mirror comparison (`>`).
 
 ---
 

--- a/docs/built_in_checks/checks/completeness/columns_are_complete_check.md
+++ b/docs/built_in_checks/checks/completeness/columns_are_complete_check.md
@@ -1,8 +1,23 @@
-# Columns Are Complete
+---
+wide: true
+---
 
-**Check**: `columns-are-complete-check`
+# Columns Are Complete Check
 
-**Purpose**: Ensures that all specified columns are fully populated with no null values. If any null is found in any of the listed columns, the entire dataset is considered invalid. This is an aggregate-level check.
+**Check name**: `columns-are-complete-check` · **Type**: aggregate · **Config**: `ColumnsAreCompleteCheckConfig`
+
+Validates that the configured columns contain **no** null values across the whole
+dataset. Use it to assert dataset-wide completeness of mandatory fields.
+
+## Parameters
+
+| Parameter  | Type        | Required | Default    | Description                                               |
+| ---------- | ----------- | -------- | ---------- | --------------------------------------------------------- |
+| `check_id` | `str`       | yes      | —          | Unique identifier for this check within the `CheckSet`.   |
+| `columns`  | `list[str]` | yes      | —          | Columns that must contain no nulls. YAML key: `columns`.  |
+| `severity` | `Severity`  | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports. |
+
+## Usage
 
 === "Python"
 
@@ -11,9 +26,9 @@
     from sparkdq.core import Severity
 
     ColumnsAreCompleteCheckConfig(
-        check_id="required-fields-complete",
-        columns=["trip_id", "pickup_time"],
-        severity=Severity.CRITICAL
+        check_id="email-complete",
+        columns=["email"],
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -21,18 +36,98 @@
 
     ```yaml
     - check: columns-are-complete-check
-      check-id: required-fields-complete
+      check-id: email-complete
       columns:
-        - trip_id
-        - pickup_time
+        - email
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Enforce that primary keys and mandatory timestamps are fully populated before downstream processing.
-- Detect data loss or corruption introduced by ETL failures or schema mismatches.
-- Use as an early pipeline gate to quarantine incomplete datasets before they reach consumers.
+- **Dataset-level verdict.** Produces a single pass/fail; the check fails if any
+  configured column has at least one null anywhere in the dataset.
+- **A critical failure fails the batch.** A failing `CRITICAL` aggregate marks
+  _every_ row `_dq_passed = False`. A `WARNING` failure is reported only.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict reports `null_counts` per column and the list of `failed_columns`.
+- **Difference from the row-level [Null Check](../null/null_check.md).** This
+  check reports a dataset-wide verdict and per-column null counts; the row-level
+  Null Check flags the individual offending rows.
+
+## Example
+
+Requiring `email` to have no nulls on a dataset where one is null, the check fails.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import ColumnsAreCompleteCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": None},
+        {"id": 3, "email": "c@example.com"},
+        {"id": 4, "email": "d@example.com"},
+    ])
+
+    check_set = CheckSet().add_check(
+        ColumnsAreCompleteCheckConfig(check_id="email-complete", columns=["email"])
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": None},
+        {"id": 3, "email": "c@example.com"},
+        {"id": 4, "email": "d@example.com"},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result reports the failure, the null count, and the failed columns:
+
+```text
+email-complete False {'null_counts': {'email': 1}, 'failed_columns': ['email']}
+```
+
+## Typical use cases
+
+- Assert that mandatory columns are fully populated before publishing a dataset.
+- Detect upstream feeds that started emitting nulls in a required field.
+- Gate downstream jobs on dataset-wide completeness.
+
+## Related checks
+
+- [Completeness Ratio Check](completeness_ratio_check.md) — tolerate a share of nulls instead of requiring zero.
+- [Null Check](../null/null_check.md) — flag the individual rows that contain nulls.
 
 ---
 

--- a/docs/built_in_checks/checks/completeness/completeness_ratio_check.md
+++ b/docs/built_in_checks/checks/completeness/completeness_ratio_check.md
@@ -1,8 +1,24 @@
-# Completeness Ratio
+---
+wide: true
+---
 
-**Check**: `completeness-ratio-check`
+# Completeness Ratio Check
 
-**Purpose**: Validates that the ratio of non-null values in a column meets or exceeds a defined threshold. Use this for soft completeness validation on fields that are expected to be mostly populated but may tolerate a small proportion of missing values.
+**Check name**: `completeness-ratio-check` · **Type**: aggregate · **Config**: `CompletenessRatioCheckConfig`
+
+Validates that the share of non-null values in a column meets a minimum ratio.
+Use it when some missing data is tolerable but should stay under a threshold.
+
+## Parameters
+
+| Parameter   | Type       | Required | Default    | Description                                                          |
+| ----------- | ---------- | -------- | ---------- | -------------------------------------------------------------------- |
+| `check_id`  | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.              |
+| `column`    | `str`      | yes      | —          | The column whose completeness is measured (a single column).         |
+| `min_ratio` | `float`    | yes      | —          | Minimum required non-null ratio, `0.0`–`1.0`. YAML key: `min-ratio`. |
+| `severity`  | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports.            |
+
+## Usage
 
 === "Python"
 
@@ -11,10 +27,10 @@
     from sparkdq.core import Severity
 
     CompletenessRatioCheckConfig(
-        check_id="pickup-time-completeness",
-        column="pickup_datetime",
-        min_ratio=0.95,
-        severity=Severity.WARNING
+        check_id="email-ratio",
+        column="email",
+        min_ratio=0.9,
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -22,17 +38,97 @@
 
     ```yaml
     - check: completeness-ratio-check
-      check-id: pickup-time-completeness
-      column: pickup_datetime
-      min-ratio: 0.95
-      severity: warning
+      check-id: email-ratio
+      column: email
+      min-ratio: 0.9
+      severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Detect columns with an unexpectedly high proportion of missing values.
-- Enforce soft completeness thresholds on optional or partially-populated fields.
-- Provide early signals for upstream data loss or extraction failures.
+- **Dataset-level verdict.** The non-null ratio is `non_null_count / total_count`;
+  the check fails when it is below `min_ratio`.
+- **A critical failure fails the batch.** A failing `CRITICAL` aggregate marks
+  _every_ row `_dq_passed = False`. A `WARNING` failure is reported only.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict reports `total_count`, `non_null_count`, `min_required_ratio`, and the
+  `actual_ratio`.
+
+## Example
+
+Requiring at least 90% non-null `email` on a dataset that is 75% complete, the
+check fails.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import CompletenessRatioCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": None},
+        {"id": 3, "email": "c@example.com"},
+        {"id": 4, "email": "d@example.com"},
+    ])
+
+    check_set = CheckSet().add_check(
+        CompletenessRatioCheckConfig(check_id="email-ratio", column="email", min_ratio=0.9)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": None},
+        {"id": 3, "email": "c@example.com"},
+        {"id": 4, "email": "d@example.com"},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result reports the failure and the observed ratio:
+
+```text
+email-ratio False {'column': 'email', 'total_count': 4, 'non_null_count': 3, 'min_required_ratio': 0.9, 'actual_ratio': 0.75}
+```
+
+## Typical use cases
+
+- Allow a tolerable amount of missing data while capping it at a threshold.
+- Monitor completeness trends of optional-but-important fields.
+- Gate publishing on a minimum fill rate.
+
+## Related checks
+
+- [Columns Are Complete Check](columns_are_complete_check.md) — require zero nulls.
+- [Null Check](../null/null_check.md) — flag the individual rows that contain nulls.
 
 ---
 

--- a/docs/built_in_checks/checks/contained_in/is_contained_in_check.md
+++ b/docs/built_in_checks/checks/contained_in/is_contained_in_check.md
@@ -1,10 +1,24 @@
-# Is Contained In
+---
+wide: true
+---
 
-**Check**: `is-contained-in-check`
+# Is Contained In Check
 
-**Purpose**: Validates that column values belong to a predefined set of allowed values. Use this to enforce domain constraints and catch unexpected or invalid categorical values early in the pipeline.
+**Check name**: `is-contained-in-check` · **Type**: row-level · **Config**: `IsContainedInCheckConfig`
 
-This check supports any data type comparable by equality (strings, integers, dates, etc.).
+Flags records whose values fall outside a predefined set of allowed values. Use
+it to enforce domain constraints and catch unexpected categorical values, working
+with any equality-comparable type (strings, integers, dates, …).
+
+## Parameters
+
+| Parameter        | Type              | Required | Default    | Description                                                                  |
+| ---------------- | ----------------- | -------- | ---------- | ---------------------------------------------------------------------------- |
+| `check_id`       | `str`             | yes      | —          | Unique identifier for this check within the `CheckSet`.                      |
+| `allowed_values` | `dict[str, list]` | yes      | —          | Mapping of column name → list of allowed values. YAML key: `allowed-values`. |
+| `severity`       | `Severity`        | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                         |
+
+## Usage
 
 === "Python"
 
@@ -13,12 +27,9 @@ This check supports any data type comparable by equality (strings, integers, dat
     from sparkdq.core import Severity
 
     IsContainedInCheckConfig(
-        check_id="valid-status-and-country",
-        allowed_values={
-            "status": ["ACTIVE", "INACTIVE", "PENDING"],
-            "country": ["DE", "FR", "IT"]
-        },
-        severity=Severity.CRITICAL
+        check_id="valid-status",
+        allowed_values={"status": ["A", "B"]},
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -26,24 +37,96 @@ This check supports any data type comparable by equality (strings, integers, dat
 
     ```yaml
     - check: is-contained-in-check
-      check-id: valid-status-and-country
+      check-id: valid-status
       allowed-values:
         status:
-          - ACTIVE
-          - INACTIVE
-          - PENDING
-        country:
-          - DE
-          - FR
-          - IT
+          - A
+          - B
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Validate that status fields contain only permitted operational states.
-- Ensure country codes or region identifiers belong to a known reference set.
-- Detect ingestion errors where unrecognized or malformed categorical values are introduced.
+- **One mapping, one or many columns.** `allowed_values` maps each column to its
+  own list of permitted values, so a single check can guard several columns at
+  once (e.g. `status` and `country`).
+- **Multi-column reduction is AND.** With multiple columns, a row is flagged only
+  when _every_ configured column holds a disallowed value. To fail a row if _any_
+  single column is out of range, configure one check per column.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`; with
+  the default severity, a failure sets `_dq_passed = False`.
+
+## Example
+
+Restricting `status` to `{A, B}`, both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import IsContainedInCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "status": "A"},
+        {"id": 2, "status": "X"},
+        {"id": 3, "status": None},
+    ])
+
+    check_set = CheckSet().add_check(
+        IsContainedInCheckConfig(check_id="valid-status", allowed_values={"status": ["A", "B"]})
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "status": "A"},
+        {"id": 2, "status": "X"},
+        {"id": 3, "status": None},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the disallowed value fails:
+
+```text
++---+------+----------------------------------------------+----------+--------------------------+
+|id |status|_dq_errors                                    |_dq_passed|_dq_validation_ts         |
++---+------+----------------------------------------------+----------+--------------------------+
+|2  |X     |[{IsContainedInCheck, valid-status, critical}]|false     |2026-01-01 00:00:00.000000|
++---+------+----------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Validate that status fields hold only permitted operational states.
+- Ensure country or region codes belong to a known reference set.
+- Detect ingestion errors introducing unrecognized categorical values.
+
+## Related checks
+
+- [Is Not Contained In Check](is_not_contained_in_check.md) — the inverse: reject a set of forbidden values.
 
 ---
 

--- a/docs/built_in_checks/checks/contained_in/is_contained_in_check.md
+++ b/docs/built_in_checks/checks/contained_in/is_contained_in_check.md
@@ -18,7 +18,7 @@ This check supports any data type comparable by equality (strings, integers, dat
             "status": ["ACTIVE", "INACTIVE", "PENDING"],
             "country": ["DE", "FR", "IT"]
         },
-        severity=Severity.ERROR
+        severity=Severity.CRITICAL
     )
     ```
 
@@ -36,7 +36,7 @@ This check supports any data type comparable by equality (strings, integers, dat
           - DE
           - FR
           - IT
-      severity: error
+      severity: critical
     ```
 
 ## Typical Use Cases

--- a/docs/built_in_checks/checks/contained_in/is_not_contained_in_check.md
+++ b/docs/built_in_checks/checks/contained_in/is_not_contained_in_check.md
@@ -1,10 +1,24 @@
-# Is Not Contained In
+---
+wide: true
+---
 
-**Check**: `is-not-contained-in-check`
+# Is Not Contained In Check
 
-**Purpose**: Validates that column values do not belong to a defined set of forbidden values. Use this to block known invalid states, test data, or disallowed categories from entering the pipeline.
+**Check name**: `is-not-contained-in-check` · **Type**: row-level · **Config**: `IsNotContainedInCheckConfig`
 
-This check supports any data type comparable by equality (strings, integers, dates, etc.).
+Flags records whose values fall inside a set of forbidden values. Use it as a
+blacklist — for example to reject deprecated status codes or known-bad
+identifiers.
+
+## Parameters
+
+| Parameter          | Type              | Required | Default    | Description                                                                      |
+| ------------------ | ----------------- | -------- | ---------- | -------------------------------------------------------------------------------- |
+| `check_id`         | `str`             | yes      | —          | Unique identifier for this check within the `CheckSet`.                          |
+| `forbidden_values` | `dict[str, list]` | yes      | —          | Mapping of column name → list of forbidden values. YAML key: `forbidden-values`. |
+| `severity`         | `Severity`        | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                             |
+
+## Usage
 
 === "Python"
 
@@ -13,12 +27,9 @@ This check supports any data type comparable by equality (strings, integers, dat
     from sparkdq.core import Severity
 
     IsNotContainedInCheckConfig(
-        check_id="no-test-or-invalid-entries",
-        forbidden_values={
-            "status": ["TEST", "DUMMY"],
-            "country": ["XX"]
-        },
-        severity=Severity.CRITICAL
+        check_id="no-deleted",
+        forbidden_values={"status": ["DELETED"]},
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -26,21 +37,92 @@ This check supports any data type comparable by equality (strings, integers, dat
 
     ```yaml
     - check: is-not-contained-in-check
-      check-id: no-test-or-invalid-entries
+      check-id: no-deleted
       forbidden-values:
         status:
-          - TEST
-          - DUMMY
-        country:
-          - XX
+          - DELETED
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Block test or dummy records from being processed in production datasets.
-- Reject entries with invalid country codes or placeholder values.
-- Detect rows carrying known-bad status values that should have been filtered upstream.
+- **One mapping, one or many columns.** `forbidden_values` maps each column to
+  its own list of disallowed values.
+- **Multi-column reduction is AND.** With multiple columns, a row is flagged only
+  when _every_ configured column holds a forbidden value. To fail a row if _any_
+  single column hits a forbidden value, configure one check per column.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`; with
+  the default severity, a failure sets `_dq_passed = False`.
+
+## Example
+
+Rejecting `status == "DELETED"`, both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import IsNotContainedInCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "status": "ACTIVE"},
+        {"id": 2, "status": "DELETED"},
+    ])
+
+    check_set = CheckSet().add_check(
+        IsNotContainedInCheckConfig(check_id="no-deleted", forbidden_values={"status": ["DELETED"]})
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "status": "ACTIVE"},
+        {"id": 2, "status": "DELETED"},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the forbidden value fails:
+
+```text
++---+-------+-----------------------------------------------+----------+--------------------------+
+|id |status |_dq_errors                                     |_dq_passed|_dq_validation_ts         |
++---+-------+-----------------------------------------------+----------+--------------------------+
+|2  |DELETED|[{IsNotContainedInCheck, no-deleted, critical}]|false     |2026-01-01 00:00:00.000000|
++---+-------+-----------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Reject deprecated or retired status codes.
+- Block known-bad identifiers or placeholder values.
+- Enforce a blacklist of disallowed categorical values.
+
+## Related checks
+
+- [Is Contained In Check](is_contained_in_check.md) — the inverse: restrict to a set of allowed values.
 
 ---
 

--- a/docs/built_in_checks/checks/count/count_between_check.md
+++ b/docs/built_in_checks/checks/count/count_between_check.md
@@ -14,7 +14,7 @@
         check_id="daily-batch-size",
         min_count=1000,
         max_count=5000,
-        severity=Severity.ERROR
+        severity=Severity.CRITICAL
     )
     ```
 
@@ -25,7 +25,7 @@
       check-id: daily-batch-size
       min-count: 1000
       max-count: 5000
-      severity: error
+      severity: critical
     ```
 
 ## Typical Use Cases

--- a/docs/built_in_checks/checks/count/count_between_check.md
+++ b/docs/built_in_checks/checks/count/count_between_check.md
@@ -1,8 +1,24 @@
-# Count Between
+---
+wide: true
+---
 
-**Check**: `row-count-between-check`
+# Row Count Between Check
 
-**Purpose**: Validates that the number of rows falls within a defined minimum and maximum range. Use this to enforce expected data volume and detect both partial loads and unintended data growth.
+**Check name**: `row-count-between-check` · **Type**: aggregate · **Config**: `RowCountBetweenCheckConfig`
+
+Validates that the dataset's row count falls within a `[min, max]` range. Use it
+to catch both partial loads (too few) and unexpected growth (too many).
+
+## Parameters
+
+| Parameter   | Type       | Required | Default    | Description                                               |
+| ----------- | ---------- | -------- | ---------- | --------------------------------------------------------- |
+| `check_id`  | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.   |
+| `min_count` | `int`      | yes      | —          | Minimum number of rows expected. YAML key: `min-count`.   |
+| `max_count` | `int`      | yes      | —          | Maximum number of rows allowed. YAML key: `max-count`.    |
+| `severity`  | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports. |
+
+## Usage
 
 === "Python"
 
@@ -11,10 +27,10 @@
     from sparkdq.core import Severity
 
     RowCountBetweenCheckConfig(
-        check_id="daily-batch-size",
-        min_count=1000,
-        max_count=5000,
-        severity=Severity.CRITICAL
+        check_id="rows-in-range",
+        min_count=10,
+        max_count=20,
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -22,17 +38,85 @@
 
     ```yaml
     - check: row-count-between-check
-      check-id: daily-batch-size
-      min-count: 1000
-      max-count: 5000
+      check-id: rows-in-range
+      min-count: 10
+      max-count: 20
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Detect partial loads (too few rows) or unintended duplications (too many rows).
-- Validate dataset size before triggering downstream jobs such as model training or reporting.
-- Catch filter changes that unintentionally affect row count.
+- **Dataset-level verdict.** Produces a single pass/fail for the whole DataFrame.
+- **A critical failure fails the batch.** A failing `CRITICAL` aggregate marks
+  _every_ row `_dq_passed = False`. A `WARNING` failure is reported only.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict is `{"actual_row_count": ..., "min_expected": ..., "max_expected": ...}`.
+
+## Example
+
+Requiring between 10 and 20 rows on a 5-row DataFrame, the check fails.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import RowCountBetweenCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": i} for i in range(1, 6)])
+
+    check_set = CheckSet().add_check(
+        RowCountBetweenCheckConfig(check_id="rows-in-range", min_count=10, max_count=20)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": i} for i in range(1, 6)])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result reports the failure and the observed count:
+
+```text
+rows-in-range False {'actual_row_count': 5, 'min_expected': 10, 'max_expected': 20}
+```
+
+## Typical use cases
+
+- Detect partial loads (too few rows) or unintended duplication (too many).
+- Validate dataset size before triggering downstream jobs.
+- Catch filter changes that unintentionally affect the row count.
+
+## Related checks
+
+- [Row Count Min Check](count_min_check.md) — enforce only a lower bound.
+- [Row Count Max Check](count_max_check.md) — enforce only an upper bound.
+- [Row Count Exact Check](count_exact_check.md) — require an exact row count.
 
 ---
 

--- a/docs/built_in_checks/checks/count/count_exact_check.md
+++ b/docs/built_in_checks/checks/count/count_exact_check.md
@@ -1,8 +1,24 @@
-# Count Exact
+---
+wide: true
+---
 
-**Check**: `row-count-exact-check`
+# Row Count Exact Check
 
-**Purpose**: Validates that the dataset contains exactly the expected number of rows. Use this to enforce strict volume contracts, particularly for fixed-size exports, snapshots, or reference datasets.
+**Check name**: `row-count-exact-check` · **Type**: aggregate · **Config**: `RowCountExactCheckConfig`
+
+Validates that the dataset contains exactly the expected number of rows. Use it
+to enforce strict volume contracts for fixed-size exports, snapshots, or
+reference datasets.
+
+## Parameters
+
+| Parameter        | Type       | Required | Default    | Description                                                    |
+| ---------------- | ---------- | -------- | ---------- | -------------------------------------------------------------- |
+| `check_id`       | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.        |
+| `expected_count` | `int`      | yes      | —          | The exact number of rows required. YAML key: `expected-count`. |
+| `severity`       | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports.      |
+
+## Usage
 
 === "Python"
 
@@ -11,9 +27,9 @@
     from sparkdq.core import Severity
 
     RowCountExactCheckConfig(
-        check_id="snapshot-row-count",
-        expected_count=500,
-        severity=Severity.CRITICAL
+        check_id="exact-rows",
+        expected_count=10,
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -21,16 +37,84 @@
 
     ```yaml
     - check: row-count-exact-check
-      check-id: snapshot-row-count
-      expected-count: 500
+      check-id: exact-rows
+      expected-count: 10
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Validate fixed-size imports where exactly a known number of records is expected.
-- Ensure integrity of snapshot-based pipelines with predictable record counts.
-- Detect silent load failures or unintended duplications early in the process.
+- **Dataset-level verdict.** Produces a single pass/fail for the whole DataFrame.
+- **A critical failure fails the batch.** A failing `CRITICAL` aggregate marks
+  _every_ row `_dq_passed = False`. A `WARNING` failure is reported only.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict is `{"actual_row_count": ..., "expected_row_count": ...}`.
+
+## Example
+
+Requiring exactly 10 rows on a 5-row DataFrame, the check fails.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import RowCountExactCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": i} for i in range(1, 6)])
+
+    check_set = CheckSet().add_check(
+        RowCountExactCheckConfig(check_id="exact-rows", expected_count=10)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": i} for i in range(1, 6)])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result reports the failure and the observed count:
+
+```text
+exact-rows False {'actual_row_count': 5, 'expected_row_count': 10}
+```
+
+## Typical use cases
+
+- Validate fixed-size imports where exactly N records are expected.
+- Ensure integrity of snapshot pipelines with a predictable record count.
+- Detect silent load failures or unintended duplication.
+
+## Related checks
+
+- [Row Count Min Check](count_min_check.md) — enforce a lower bound.
+- [Row Count Max Check](count_max_check.md) — enforce an upper bound.
+- [Row Count Between Check](count_between_check.md) — enforce a range.
 
 ---
 

--- a/docs/built_in_checks/checks/count/count_exact_check.md
+++ b/docs/built_in_checks/checks/count/count_exact_check.md
@@ -13,7 +13,7 @@
     RowCountExactCheckConfig(
         check_id="snapshot-row-count",
         expected_count=500,
-        severity=Severity.ERROR
+        severity=Severity.CRITICAL
     )
     ```
 
@@ -23,7 +23,7 @@
     - check: row-count-exact-check
       check-id: snapshot-row-count
       expected-count: 500
-      severity: error
+      severity: critical
     ```
 
 ## Typical Use Cases

--- a/docs/built_in_checks/checks/count/count_max_check.md
+++ b/docs/built_in_checks/checks/count/count_max_check.md
@@ -1,8 +1,23 @@
-# Count Max
+---
+wide: true
+---
 
-**Check**: `row-count-max-check`
+# Row Count Max Check
 
-**Purpose**: Validates that the dataset does not exceed a defined maximum number of rows. Use this to detect unexpected data growth, runaway joins, or accidental full loads when only incremental data is expected.
+**Check name**: `row-count-max-check` · **Type**: aggregate · **Config**: `RowCountMaxCheckConfig`
+
+Validates that the dataset does not exceed a maximum number of rows. Use it to
+detect unexpected data growth, runaway joins, or accidental full loads.
+
+## Parameters
+
+| Parameter   | Type       | Required | Default    | Description                                               |
+| ----------- | ---------- | -------- | ---------- | --------------------------------------------------------- |
+| `check_id`  | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.   |
+| `max_count` | `int`      | yes      | —          | Maximum number of rows allowed. YAML key: `max-count`.    |
+| `severity`  | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports. |
+
+## Usage
 
 === "Python"
 
@@ -11,9 +26,9 @@
     from sparkdq.core import Severity
 
     RowCountMaxCheckConfig(
-        check_id="batch-size-upper-bound",
-        max_count=100000,
-        severity=Severity.CRITICAL
+        check_id="max-rows",
+        max_count=3,
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -21,16 +36,84 @@
 
     ```yaml
     - check: row-count-max-check
-      check-id: batch-size-upper-bound
-      max-count: 100000
+      check-id: max-rows
+      max-count: 3
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Detect abnormal data growth that may indicate duplicates or incorrect joins.
+- **Dataset-level verdict.** Produces a single pass/fail for the whole DataFrame.
+- **A critical failure fails the batch.** A failing `CRITICAL` aggregate marks
+  _every_ row `_dq_passed = False`. A `WARNING` failure is reported only.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict is `{"actual_row_count": ..., "max_expected": ...}`.
+
+## Example
+
+Allowing at most 3 rows on a 5-row DataFrame, the check fails.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import RowCountMaxCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": i} for i in range(1, 6)])
+
+    check_set = CheckSet().add_check(
+        RowCountMaxCheckConfig(check_id="max-rows", max_count=3)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": i} for i in range(1, 6)])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result reports the failure and the observed count:
+
+```text
+max-rows False {'actual_row_count': 5, 'max_expected': 3}
+```
+
+## Typical use cases
+
+- Detect abnormal data growth from duplicates or incorrect joins.
 - Prevent downstream systems from processing unexpectedly large datasets.
 - Catch accidental full loads when only an incremental extract was intended.
+
+## Related checks
+
+- [Row Count Min Check](count_min_check.md) — enforce a lower row-count bound.
+- [Row Count Between Check](count_between_check.md) — enforce a row-count range.
+- [Row Count Exact Check](count_exact_check.md) — require an exact row count.
 
 ---
 

--- a/docs/built_in_checks/checks/count/count_max_check.md
+++ b/docs/built_in_checks/checks/count/count_max_check.md
@@ -13,7 +13,7 @@
     RowCountMaxCheckConfig(
         check_id="batch-size-upper-bound",
         max_count=100000,
-        severity=Severity.ERROR
+        severity=Severity.CRITICAL
     )
     ```
 
@@ -23,7 +23,7 @@
     - check: row-count-max-check
       check-id: batch-size-upper-bound
       max-count: 100000
-      severity: error
+      severity: critical
     ```
 
 ## Typical Use Cases

--- a/docs/built_in_checks/checks/count/count_min_check.md
+++ b/docs/built_in_checks/checks/count/count_min_check.md
@@ -1,8 +1,23 @@
-# Count Min
+---
+wide: true
+---
 
-**Check**: `row-count-min-check`
+# Row Count Min Check
 
-**Purpose**: Validates that the dataset contains at least a defined minimum number of rows. Use this to prevent downstream processing on incomplete or unexpectedly small datasets.
+**Check name**: `row-count-min-check` · **Type**: aggregate · **Config**: `RowCountMinCheckConfig`
+
+Validates that the dataset contains at least a minimum number of rows. Use it to
+stop downstream processing on incomplete or unexpectedly small datasets.
+
+## Parameters
+
+| Parameter   | Type       | Required | Default    | Description                                               |
+| ----------- | ---------- | -------- | ---------- | --------------------------------------------------------- |
+| `check_id`  | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.   |
+| `min_count` | `int`      | yes      | —          | Minimum number of rows expected. YAML key: `min-count`.   |
+| `severity`  | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports. |
+
+## Usage
 
 === "Python"
 
@@ -11,9 +26,9 @@
     from sparkdq.core import Severity
 
     RowCountMinCheckConfig(
-        check_id="minimum-record-count",
-        min_count=10000,
-        severity=Severity.WARNING
+        check_id="min-rows",
+        min_count=1000,
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -21,16 +36,87 @@
 
     ```yaml
     - check: row-count-min-check
-      check-id: minimum-record-count
-      min-count: 10000
-      severity: warning
+      check-id: min-rows
+      min-count: 1000
+      severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Detect partial loads or failed data transfers that result in fewer records than expected.
-- Enforce minimum data volume requirements for reliable analytics, reporting, or model training.
-- Prevent downstream processes from running on datasets that are too small to be meaningful.
+- **Dataset-level verdict.** As an aggregate check, it produces a single
+  pass/fail for the whole DataFrame rather than a per-row flag.
+- **A critical failure fails the batch.** When a `CRITICAL` aggregate check fails,
+  _every_ row is marked `_dq_passed = False`, so `pass_df()` is empty and
+  `fail_df()` holds all rows. A `WARNING` failure is reported without failing rows.
+- **Result and metrics.** The outcome is available via
+  `result.aggregate_results`; each carries `passed` and a `metrics` dict — here
+  `{"actual_row_count": ..., "min_expected": ...}`.
+
+## Example
+
+Requiring at least 1000 rows on a 5-row DataFrame, the check fails.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import RowCountMinCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": i} for i in range(1, 6)])
+
+    check_set = CheckSet().add_check(
+        RowCountMinCheckConfig(check_id="min-rows", min_count=1000)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": i} for i in range(1, 6)])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result reports the failure and the observed count:
+
+```text
+min-rows False {'actual_row_count': 5, 'min_expected': 1000}
+```
+
+## Typical use cases
+
+- Detect partial loads or failed transfers that yield too few records.
+- Enforce a minimum data volume before analytics, reporting, or model training.
+- Prevent downstream runs on datasets too small to be meaningful.
+
+## Related checks
+
+- [Row Count Max Check](count_max_check.md) — enforce an upper row-count bound.
+- [Row Count Between Check](count_between_check.md) — enforce a row-count range.
+- [Row Count Exact Check](count_exact_check.md) — require an exact row count.
 
 ---
 

--- a/docs/built_in_checks/checks/date/date_between_check.md
+++ b/docs/built_in_checks/checks/date/date_between_check.md
@@ -1,17 +1,26 @@
-# Date Between
+---
+wide: true
+---
 
-**Check**: `date-between-check`
+# Date Between Check
 
-**Purpose**: Validates that values in date columns fall within a defined range. A row fails if any selected column contains a date before `min_value` or after `max_value`.
+**Check name**: `date-between-check` · **Type**: row-level · **Config**: `DateBetweenCheckConfig`
 
-Use the `inclusive` parameter to control boundary behavior:
+Flags any record whose value in one of the configured date columns falls outside
+a `[min, max]` date range. Use it to constrain dates to a valid business period.
 
-| Value                      | Behavior                                   |
-| -------------------------- | ------------------------------------------ |
-| `[false, false]` (default) | strictly between: `min < value < max`      |
-| `[true, false]`            | include lower bound: `min <= value < max`  |
-| `[false, true]`            | include upper bound: `min < value <= max`  |
-| `[true, true]`             | include both bounds: `min <= value <= max` |
+## Parameters
+
+| Parameter   | Type                | Required | Default          | Description                                                     |
+| ----------- | ------------------- | -------- | ---------------- | --------------------------------------------------------------- |
+| `check_id`  | `str`               | yes      | —                | Unique identifier for this check within the `CheckSet`.         |
+| `columns`   | `list[str]`         | yes      | —                | Date columns to compare against the range. YAML key: `columns`. |
+| `min_value` | `str`               | yes      | —                | Lower bound as `YYYY-MM-DD`. YAML key: `min-value`.             |
+| `max_value` | `str`               | yes      | —                | Upper bound as `YYYY-MM-DD`. YAML key: `max-value`.             |
+| `inclusive` | `tuple[bool, bool]` | no       | `(False, False)` | Inclusivity of the lower and upper bound respectively.          |
+| `severity`  | `Severity`          | no       | `CRITICAL`       | `CRITICAL` fails the row; `WARNING` only records it.            |
+
+## Usage
 
 === "Python"
 
@@ -20,12 +29,12 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     DateBetweenCheckConfig(
-        check_id="record-date-within-range",
-        columns=["record_date"],
-        min_value="2020-01-01",
-        max_value="2023-12-31",
+        check_id="date-2024",
+        columns=["d"],
+        min_value="2024-01-01",
+        max_value="2024-12-31",
         inclusive=(True, True),
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -33,20 +42,108 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: date-between-check
-      check-id: record-date-within-range
+      check-id: date-2024
       columns:
-        - record_date
-      min-value: "2020-01-01"
-      max-value: "2023-12-31"
+        - d
+      min-value: "2024-01-01"
+      max-value: "2024-12-31"
       inclusive: [true, true]
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure transaction or event dates fall within a valid business or fiscal period.
-- Prevent processing of records with dates outside the expected reporting window.
-- Reject future-dated or historically stale records before they reach downstream consumers.
+- **Bounds are `YYYY-MM-DD` strings.** The column is cast to `date` before
+  comparison.
+- **`inclusive` is a `(lower, upper)` pair and defaults to `(False, False)`** —
+  i.e. strictly between. Each bound is controlled independently (`(True, True)`
+  gives `min <= value <= max`).
+- **OR semantics across columns.** With multiple columns, a record fails if
+  _any_ of them lies outside the range.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`; with
+  the default severity, a failure sets `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist, the check
+  raises `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `d` within calendar year 2024 (both bounds inclusive), both styles
+produce the same result.
+
+=== "Python"
+
+    ```python
+    import datetime
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import DateBetweenCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "d": datetime.date(2024, 6, 1)},
+        {"id": 2, "d": datetime.date(2023, 1, 1)},
+        {"id": 3, "d": datetime.date(2025, 1, 1)},
+    ])
+
+    check_set = CheckSet().add_check(
+        DateBetweenCheckConfig(
+            check_id="date-2024", columns=["d"],
+            min_value="2024-01-01", max_value="2024-12-31", inclusive=(True, True),
+        )
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import datetime
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "d": datetime.date(2024, 6, 1)},
+        {"id": 2, "d": datetime.date(2023, 1, 1)},
+        {"id": 3, "d": datetime.date(2025, 1, 1)},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Both out-of-range rows fail; the in-range row passes:
+
+```text
++----------+---+-----------------------------------------+----------+--------------------------+
+|d         |id |_dq_errors                               |_dq_passed|_dq_validation_ts         |
++----------+---+-----------------------------------------+----------+--------------------------+
+|2023-01-01|2  |[{DateBetweenCheck, date-2024, critical}]|false     |2026-01-01 00:00:00.000000|
+|2025-01-01|3  |[{DateBetweenCheck, date-2024, critical}]|false     |2026-01-01 00:00:00.000000|
++----------+---+-----------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Constrain event or transaction dates to a valid business period.
+- Reject records outside a reporting or fiscal window.
+- Detect date errors from upstream systems or migrations.
+
+## Related checks
+
+- [Date Min Check](date_min_check.md) — enforce only a lower date bound.
+- [Date Max Check](date_max_check.md) — enforce only an upper date bound.
 
 ---
 

--- a/docs/built_in_checks/checks/date/date_max_check.md
+++ b/docs/built_in_checks/checks/date/date_max_check.md
@@ -1,13 +1,26 @@
-# Date Max
+---
+wide: true
+---
 
-**Check**: `date-max-check`
+# Date Max Check
 
-**Purpose**: Validates that values in date columns do not exceed a defined maximum date. A row fails if any selected column contains a date after `max_value`.
+**Check name**: `date-max-check` · **Type**: row-level · **Config**: `DateMaxCheckConfig`
 
-Use the `inclusive` parameter to control boundary behavior:
+Flags any record whose value in one of the configured date columns is later than
+a maximum date. Use it to reject future-dated records or dates beyond a valid
+reporting window.
 
-- `inclusive: false` (default) — `value < max_value`
-- `inclusive: true` — `value <= max_value`
+## Parameters
+
+| Parameter   | Type        | Required | Default    | Description                                                         |
+| ----------- | ----------- | -------- | ---------- | ------------------------------------------------------------------- |
+| `check_id`  | `str`       | yes      | —          | Unique identifier for this check within the `CheckSet`.             |
+| `columns`   | `list[str]` | yes      | —          | Date columns to compare against the threshold. YAML key: `columns`. |
+| `max_value` | `str`       | yes      | —          | Upper bound as `YYYY-MM-DD`. YAML key: `max-value`.                 |
+| `inclusive` | `bool`      | no       | `False`    | Whether `max_value` itself is allowed (see Behavior).               |
+| `severity`  | `Severity`  | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                |
+
+## Usage
 
 === "Python"
 
@@ -16,11 +29,11 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     DateMaxCheckConfig(
-        check_id="record-date-not-in-future",
-        columns=["record_date"],
-        max_value="2023-12-31",
+        check_id="max-date",
+        columns=["d"],
+        max_value="2024-12-31",
         inclusive=True,
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -28,19 +41,100 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: date-max-check
-      check-id: record-date-not-in-future
+      check-id: max-date
       columns:
-        - record_date
-      max-value: "2023-12-31"
+        - d
+      max-value: "2024-12-31"
       inclusive: true
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure that event or transaction dates do not lie in the future.
-- Enforce a cutoff date for a reporting period or fiscal year end.
-- Detect future-dated records caused by data entry errors or timezone misconfiguration.
+- **`max_value` is a `YYYY-MM-DD` string.** The column is cast to `date` before
+  comparison.
+- **`inclusive` controls the boundary, and defaults to `False`.** With
+  `inclusive=True`, a value equal to `max_value` **passes** (`value <= max_value`).
+  With the default, the boundary date itself **fails** (`value < max_value`).
+- **OR semantics across columns.** With multiple columns, a record fails if
+  _any_ of them is after the threshold.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`; with
+  the default severity, a failure sets `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist, the check
+  raises `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `d <= 2024-12-31` (`inclusive=True`), both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    import datetime
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import DateMaxCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "d": datetime.date(2024, 6, 1)},
+        {"id": 2, "d": datetime.date(2025, 2, 1)},
+    ])
+
+    check_set = CheckSet().add_check(
+        DateMaxCheckConfig(check_id="max-date", columns=["d"], max_value="2024-12-31", inclusive=True)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import datetime
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "d": datetime.date(2024, 6, 1)},
+        {"id": 2, "d": datetime.date(2025, 2, 1)},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the too-late row fails:
+
+```text
++----------+---+------------------------------------+----------+--------------------------+
+|d         |id |_dq_errors                          |_dq_passed|_dq_validation_ts         |
++----------+---+------------------------------------+----------+--------------------------+
+|2025-02-01|2  |[{DateMaxCheck, max-date, critical}]|false     |2026-01-01 00:00:00.000000|
++----------+---+------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Reject future-dated records where only past dates are valid.
+- Enforce an upper bound aligned with a reporting or snapshot window.
+- Detect clock or timezone errors producing out-of-range dates.
+
+## Related checks
+
+- [Date Min Check](date_min_check.md) — enforce a lower date bound.
+- [Date Between Check](date_between_check.md) — enforce both date bounds at once.
 
 ---
 

--- a/docs/built_in_checks/checks/date/date_min_check.md
+++ b/docs/built_in_checks/checks/date/date_min_check.md
@@ -1,13 +1,26 @@
-# Date Min
+---
+wide: true
+---
 
-**Check**: `date-min-check`
+# Date Min Check
 
-**Purpose**: Validates that values in date columns are not earlier than a defined minimum date. A row fails if any selected column contains a date before `min_value`.
+**Check name**: `date-min-check` · **Type**: row-level · **Config**: `DateMinCheckConfig`
 
-Use the `inclusive` parameter to control boundary behavior:
+Flags any record whose value in one of the configured date columns is earlier
+than a minimum date. Use it to reject records before an operational start date or
+system go-live.
 
-- `inclusive: false` (default) — `value > min_value`
-- `inclusive: true` — `value >= min_value`
+## Parameters
+
+| Parameter   | Type        | Required | Default    | Description                                                         |
+| ----------- | ----------- | -------- | ---------- | ------------------------------------------------------------------- |
+| `check_id`  | `str`       | yes      | —          | Unique identifier for this check within the `CheckSet`.             |
+| `columns`   | `list[str]` | yes      | —          | Date columns to compare against the threshold. YAML key: `columns`. |
+| `min_value` | `str`       | yes      | —          | Lower bound as `YYYY-MM-DD`. YAML key: `min-value`.                 |
+| `inclusive` | `bool`      | no       | `False`    | Whether `min_value` itself is allowed (see Behavior).               |
+| `severity`  | `Severity`  | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                |
+
+## Usage
 
 === "Python"
 
@@ -16,11 +29,11 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     DateMinCheckConfig(
-        check_id="record-date-not-before-start",
-        columns=["record_date"],
-        min_value="2020-01-01",
+        check_id="min-date",
+        columns=["d"],
+        min_value="2024-01-01",
         inclusive=True,
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -28,19 +41,100 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: date-min-check
-      check-id: record-date-not-before-start
+      check-id: min-date
       columns:
-        - record_date
-      min-value: "2020-01-01"
+        - d
+      min-value: "2024-01-01"
       inclusive: true
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure that event or transaction dates are not earlier than the defined operational start date.
-- Reject legacy or historically stale records outside the valid business period.
-- Validate that data entries are aligned with a system go-live or migration cutover date.
+- **`min_value` is a `YYYY-MM-DD` string.** The column is cast to `date` before
+  comparison.
+- **`inclusive` controls the boundary, and defaults to `False`.** With
+  `inclusive=True`, a value equal to `min_value` **passes** (`value >= min_value`).
+  With the default, the boundary date itself **fails** (`value > min_value`).
+- **OR semantics across columns.** With multiple columns, a record fails if
+  _any_ of them is before the threshold.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`; with
+  the default severity, a failure sets `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist, the check
+  raises `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `d >= 2024-01-01` (`inclusive=True`), both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    import datetime
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import DateMinCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "d": datetime.date(2024, 6, 1)},
+        {"id": 2, "d": datetime.date(2023, 12, 31)},
+    ])
+
+    check_set = CheckSet().add_check(
+        DateMinCheckConfig(check_id="min-date", columns=["d"], min_value="2024-01-01", inclusive=True)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import datetime
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "d": datetime.date(2024, 6, 1)},
+        {"id": 2, "d": datetime.date(2023, 12, 31)},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the too-early row fails:
+
+```text
++----------+---+------------------------------------+----------+--------------------------+
+|d         |id |_dq_errors                          |_dq_passed|_dq_validation_ts         |
++----------+---+------------------------------------+----------+--------------------------+
+|2023-12-31|2  |[{DateMinCheck, min-date, critical}]|false     |2026-01-01 00:00:00.000000|
++----------+---+------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Ensure event or transaction dates are not before an operational start date.
+- Reject historically stale records outside the valid business period.
+- Align entries with a go-live or migration cutover date.
+
+## Related checks
+
+- [Date Max Check](date_max_check.md) — enforce an upper date bound.
+- [Date Between Check](date_between_check.md) — enforce both date bounds at once.
 
 ---
 

--- a/docs/built_in_checks/checks/freshness/freshness_check.md
+++ b/docs/built_in_checks/checks/freshness/freshness_check.md
@@ -1,12 +1,26 @@
+---
+wide: true
+---
+
 # Freshness Check
 
-**Check**: `freshness-check`
+**Check name**: `freshness-check` · **Type**: aggregate · **Config**: `FreshnessCheckConfig`
 
-**Purpose**: Validates that the most recent timestamp in a column is within a defined interval relative to the current system time. The check fails if the newest value is older than the specified threshold.
+Validates that the most recent timestamp in a column is within a configured
+recency window. Use it to detect stale datasets — feeds that stopped updating or
+arrived late.
 
-!!! note
-Supported values for the `period` parameter:
-`year`, `month`, `week`, `day`, `hour`, `minute`, `second`
+## Parameters
+
+| Parameter  | Type       | Required | Default    | Description                                                                       |
+| ---------- | ---------- | -------- | ---------- | --------------------------------------------------------------------------------- |
+| `check_id` | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.                           |
+| `column`   | `str`      | yes      | —          | The timestamp column to evaluate.                                                 |
+| `interval` | `int`      | yes      | —          | Size of the recency window; must be positive.                                     |
+| `period`   | `str`      | yes      | —          | Time unit (singular): `year`, `month`, `week`, `day`, `hour`, `minute`, `second`. |
+| `severity` | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports.                         |
+
+## Usage
 
 === "Python"
 
@@ -15,11 +29,11 @@ Supported values for the `period` parameter:
     from sparkdq.core import Severity
 
     FreshnessCheckConfig(
-        check_id="last-updated-within-24h",
-        column="last_updated",
-        interval=24,
-        period="hour",
-        severity=Severity.CRITICAL
+        check_id="data-fresh",
+        column="event_ts",
+        interval=1,
+        period="day",
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -27,18 +41,96 @@ Supported values for the `period` parameter:
 
     ```yaml
     - check: freshness-check
-      check-id: last-updated-within-24h
-      column: last_updated
-      interval: 24
-      period: hour
+      check-id: data-fresh
+      column: event_ts
+      interval: 1
+      period: day
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure that ingested data has been updated within the expected frequency.
-- Detect delays or failures in upstream ingestion pipelines before they affect consumers.
-- Monitor SLA compliance by enforcing a freshness threshold for reporting or analytics datasets.
+- **Compares against `current_timestamp()`.** The check passes when
+  `max(column) >= now - interval period`. It is evaluated at run time, so the
+  verdict depends on when the pipeline runs.
+- **`period` is singular.** Use `day`, not `days` — an invalid unit raises a
+  validation error at config time. `interval` must be positive, or the config
+  raises `InvalidCheckConfigurationError`.
+- **A critical failure fails the batch.** A failing `CRITICAL` aggregate marks
+  _every_ row `_dq_passed = False`. A `WARNING` failure is reported only.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict reports the observed `max_timestamp` and the `freshness_threshold`.
+
+## Example
+
+Requiring data no older than 1 day, on a dataset whose latest timestamp is from
+2020, the check fails.
+
+=== "Python"
+
+    ```python
+    import datetime
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import FreshnessCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "event_ts": datetime.datetime(2020, 1, 1, 0, 0, 0)},
+    ])
+
+    check_set = CheckSet().add_check(
+        FreshnessCheckConfig(check_id="data-fresh", column="event_ts", interval=1, period="day")
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import datetime
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "event_ts": datetime.datetime(2020, 1, 1, 0, 0, 0)},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result reports the latest timestamp and the threshold:
+
+```text
+data-fresh False {'max_timestamp': '2020-01-01 00:00:00', 'freshness_threshold': '1 day'}
+```
+
+## Typical use cases
+
+- Detect feeds that stopped updating or arrived late.
+- Gate downstream jobs on data recency (e.g. "must be < 1 hour old").
+- Monitor SLA compliance for periodic loads.
+
+## Related checks
+
+- [Timestamp Max Check](../timestamp/timestamp_max_check.md) — bound timestamps against a fixed instant rather than "now".
 
 ---
 

--- a/docs/built_in_checks/checks/integrity/foreign_key_check.md
+++ b/docs/built_in_checks/checks/integrity/foreign_key_check.md
@@ -1,8 +1,26 @@
+---
+wide: true
+---
+
 # Foreign Key Check
 
-**Check**: `foreign-key-check`
+**Check name**: `foreign-key-check` · **Type**: aggregate (integrity) · **Config**: `ForeignKeyCheckConfig`
 
-**Purpose**: Validates that all values in a column exist in a reference dataset's column. The check fails if any value in the source column cannot be resolved in the referenced column. This is an aggregate-level check that reports the count and ratio of unresolvable references.
+Validates referential integrity: every value in a source column must exist in a
+column of a **reference dataset**. Use it to enforce foreign-key relationships
+between a fact table and its dimensions.
+
+## Parameters
+
+| Parameter           | Type       | Required | Default    | Description                                                                             |
+| ------------------- | ---------- | -------- | ---------- | --------------------------------------------------------------------------------------- |
+| `check_id`          | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.                                 |
+| `column`            | `str`      | yes      | —          | The source column to validate.                                                          |
+| `reference_dataset` | `str`      | yes      | —          | Name of the reference dataset. YAML key: `reference-dataset`.                           |
+| `reference_column`  | `str`      | yes      | —          | The column in the reference dataset holding valid values. YAML key: `reference-column`. |
+| `severity`          | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports.                               |
+
+## Usage
 
 === "Python"
 
@@ -11,11 +29,11 @@
     from sparkdq.core import Severity
 
     ForeignKeyCheckConfig(
-        check_id="customer-id-resolvable",
+        check_id="customer-resolvable",
         column="customer_id",
         reference_dataset="customers",
-        reference_column="id",
-        severity=Severity.CRITICAL
+        reference_column="cid",
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -23,18 +41,106 @@
 
     ```yaml
     - check: foreign-key-check
-      check-id: customer-id-resolvable
+      check-id: customer-resolvable
       column: customer_id
       reference-dataset: customers
-      reference-column: id
+      reference-column: cid
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure every `order.customer_id` resolves to an existing entry in the `customers` table.
-- Validate foreign key references in fact tables against known dimension entries.
-- Enforce referential integrity between datasets in data lakes or data warehouses.
+- **Reference datasets are passed to `run_batch`.** The named dataset must be
+  supplied via `run_batch(df, reference_datasets={"customers": customers_df})`;
+  the name must match `reference_dataset`. A missing name raises
+  `MissingReferenceDatasetError`.
+- **Dataset-level verdict.** The check fails if any source value cannot be
+  resolved. Because it is a `CRITICAL` aggregate by default, a failure marks
+  **every** row `_dq_passed = False` — including rows whose own key was valid.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict reports `missing_foreign_keys`, `total_rows`, and `missing_ratio`.
+
+## Example
+
+Validating `customer_id` against a `customers` reference, where one value is
+unresolved.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import ForeignKeyCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    orders = spark.createDataFrame([
+        {"id": 1, "customer_id": 10},
+        {"id": 2, "customer_id": 99},
+    ])
+    customers = spark.createDataFrame([{"cid": 10}, {"cid": 20}])
+
+    check_set = CheckSet().add_check(
+        ForeignKeyCheckConfig(
+            check_id="customer-resolvable",
+            column="customer_id",
+            reference_dataset="customers",
+            reference_column="cid",
+        )
+    )
+    result = BatchDQEngine(check_set).run_batch(
+        orders, reference_datasets={"customers": customers}
+    )
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    orders = spark.createDataFrame([
+        {"id": 1, "customer_id": 10},
+        {"id": 2, "customer_id": 99},
+    ])
+    customers = spark.createDataFrame([{"cid": 10}, {"cid": 20}])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(
+        orders, reference_datasets={"customers": customers}
+    )
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result reports the unresolved count and ratio:
+
+```text
+customer-resolvable False {'missing_foreign_keys': 1, 'total_rows': 2, 'missing_ratio': 0.5}
+```
+
+## Typical use cases
+
+- Ensure every `order.customer_id` resolves to a known customer.
+- Validate fact-table foreign keys against dimension tables.
+- Enforce referential integrity across datasets in a lake or warehouse.
+
+## Related checks
+
+- [Is Contained In Check](../contained_in/is_contained_in_check.md) — restrict values to a static in-config set rather than a reference dataset.
 
 ---
 

--- a/docs/built_in_checks/checks/null/exactly_one_not_null_check.md
+++ b/docs/built_in_checks/checks/null/exactly_one_not_null_check.md
@@ -1,8 +1,25 @@
+---
+wide: true
+---
+
 # Exactly One Not Null Check
 
-**Check**: `exactly-one-not-null-check`
+**Check name**: `exactly-one-not-null-check` · **Type**: row-level · **Config**: `ExactlyOneNotNullCheckConfig`
 
-**Purpose**: Enforces that exactly one of the specified columns is non-null per row. A row fails if none or more than one of the columns are populated. Use this to enforce mutual exclusivity across optional identifiers or contact channels.
+Enforces that exactly one of the configured columns is non-null per record. A row
+fails if none or more than one of the columns are populated. Use it for mutually
+exclusive fields such as alternative identifiers or contact channels, where
+exactly one option must be chosen.
+
+## Parameters
+
+| Parameter  | Type        | Required | Default    | Description                                                            |
+| ---------- | ----------- | -------- | ---------- | ---------------------------------------------------------------------- |
+| `check_id` | `str`       | yes      | —          | Unique identifier for this check within the `CheckSet`.                |
+| `columns`  | `list[str]` | yes      | —          | Columns among which exactly one must be non-null. YAML key: `columns`. |
+| `severity` | `Severity`  | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                   |
+
+## Usage
 
 === "Python"
 
@@ -11,9 +28,9 @@
     from sparkdq.core import Severity
 
     ExactlyOneNotNullCheckConfig(
-        check_id="single-contact-method",
-        columns=["email", "phone", "user_id"],
-        severity=Severity.CRITICAL
+        check_id="one-contact",
+        columns=["phone", "email"],
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -21,19 +38,101 @@
 
     ```yaml
     - check: exactly-one-not-null-check
-      check-id: single-contact-method
+      check-id: one-contact
       columns:
-        - email
         - phone
-        - user_id
+        - email
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Enforce that exactly one of several optional identifiers (e.g., email, phone, user_id) is provided per record.
-- Prevent ambiguous records where multiple mutually exclusive fields are populated simultaneously.
+- **Exactly-one semantics.** A record passes only when precisely one of the
+  listed columns is non-null. It fails both when _zero_ columns are populated and
+  when _two or more_ are.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`;
+  passing rows are unaffected. With the default severity, a failure sets
+  `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist in the
+  DataFrame, the check raises `MissingColumnError` at validation time rather than
+  silently passing.
+
+## Example
+
+Given a DataFrame that must carry exactly one of `phone` or `email`, both styles
+produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import ExactlyOneNotNullCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "phone": "123", "email": None},
+        {"id": 2, "phone": None, "email": None},
+        {"id": 3, "phone": "555", "email": "b@example.com"},
+    ])
+
+    check_set = CheckSet().add_check(
+        ExactlyOneNotNullCheckConfig(check_id="one-contact", columns=["phone", "email"])
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "phone": "123", "email": None},
+        {"id": 2, "phone": None, "email": None},
+        {"id": 3, "phone": "555", "email": "b@example.com"},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Both violating rows are returned — the one with no contact and the one with two:
+
+```text
++-------------+---+-----+-------------------------------------------------+----------+--------------------------+
+|email        |id |phone|_dq_errors                                       |_dq_passed|_dq_validation_ts         |
++-------------+---+-----+-------------------------------------------------+----------+--------------------------+
+|NULL         |2  |NULL |[{ExactlyOneNotNullCheck, one-contact, critical}]|false     |2026-01-01 00:00:00.000000|
+|b@example.com|3  |555  |[{ExactlyOneNotNullCheck, one-contact, critical}]|false     |2026-01-01 00:00:00.000000|
++-------------+---+-----+-------------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Enforce that exactly one of several optional identifiers (e.g. `email`,
+  `phone`, `user_id`) is provided per record.
+- Prevent ambiguous records where multiple mutually exclusive fields are
+  populated at once.
 - Detect rows where no identification channel is present at all.
+
+## Related checks
+
+- [Null Check](null_check.md) — require one or more columns to be populated.
+- [Not Null Check](not_null_check.md) — require columns to stay null.
 
 ---
 

--- a/docs/built_in_checks/checks/null/not_null_check.md
+++ b/docs/built_in_checks/checks/null/not_null_check.md
@@ -1,8 +1,25 @@
+---
+wide: true
+---
+
 # Not Null Check
 
-**Check**: `not-null-check`
+**Check name**: `not-null-check` · **Type**: row-level · **Config**: `NotNullCheckConfig`
 
-**Purpose**: Ensures that the specified columns contain at least one non-null value. Use this check to detect columns that are completely empty, which typically indicates a broken upstream feed or a deprecated field still present in the schema.
+Flags any record where one or more of the configured columns contains a value —
+that is, it asserts the columns are expected to stay **null**. Use it for fields
+that should remain unset under normal business conditions, such as a
+`deleted_at` or `error_reason` that must be empty for active records.
+
+## Parameters
+
+| Parameter  | Type        | Required | Default    | Description                                             |
+| ---------- | ----------- | -------- | ---------- | ------------------------------------------------------- |
+| `check_id` | `str`       | yes      | —          | Unique identifier for this check within the `CheckSet`. |
+| `columns`  | `list[str]` | yes      | —          | Columns that must remain null. YAML key: `columns`.     |
+| `severity` | `Severity`  | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.    |
+
+## Usage
 
 === "Python"
 
@@ -11,9 +28,9 @@
     from sparkdq.core import Severity
 
     NotNullCheckConfig(
-        check_id="deactivated-at-has-values",
-        columns=["deactivated_at"],
-        severity=Severity.WARNING
+        check_id="deleted-at-empty",
+        columns=["deleted_at"],
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -21,17 +38,101 @@
 
     ```yaml
     - check: not-null-check
-      check-id: deactivated-at-has-values
+      check-id: deleted-at-empty
       columns:
-        - deactivated_at
-      severity: warning
+        - deleted_at
+      severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Detect columns that are fully empty due to upstream data issues or broken feeds.
-- Identify deprecated schema fields that are no longer populated.
-- Guard against silent data loss where an entire column goes missing after a pipeline change.
+- **OR semantics across columns.** A record fails if _any_ of the listed columns
+  is non-null. It is the inverse of the [Null Check](null_check.md).
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`;
+  passing rows are unaffected. With the default severity, a failure sets
+  `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist in the
+  DataFrame, the check raises `MissingColumnError` at validation time rather than
+  silently passing.
+
+## Example
+
+Given a DataFrame where `deleted_at` should be empty for every row, both styles
+produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import NotNullCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "deleted_at": None},
+        {"id": 2, "deleted_at": "2026-01-05"},
+        {"id": 3, "deleted_at": None},
+    ])
+
+    check_set = CheckSet().add_check(
+        NotNullCheckConfig(check_id="deleted-at-empty", columns=["deleted_at"])
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "deleted_at": None},
+        {"id": 2, "deleted_at": "2026-01-05"},
+        {"id": 3, "deleted_at": None},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+The failing row is returned with its error metadata:
+
+```text
++----------+---+--------------------------------------------+----------+--------------------------+
+|deleted_at|id |_dq_errors                                  |_dq_passed|_dq_validation_ts         |
++----------+---+--------------------------------------------+----------+--------------------------+
+|2026-01-05|2  |[{NotNullCheck, deleted-at-empty, critical}]|false     |2026-01-01 00:00:00.000000|
++----------+---+--------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Assert that lifecycle columns like `deleted_at` or `archived_at` are empty for
+  records that should still be active.
+- Enforce that an `error_reason` or `rejection_code` is null on successfully
+  processed rows.
+- Catch upstream logic that unexpectedly populates a field that should stay
+  unset.
+
+## Related checks
+
+- [Null Check](null_check.md) — the inverse assertion for columns that must be
+  populated.
+- [Exactly One Not Null Check](exactly_one_not_null_check.md) — require exactly
+  one of several columns to be populated.
 
 ---
 

--- a/docs/built_in_checks/checks/null/null_check.md
+++ b/docs/built_in_checks/checks/null/null_check.md
@@ -13,7 +13,7 @@
     NullCheckConfig(
         check_id="no-null-email",
         columns=["email"],
-        severity=Severity.ERROR
+        severity=Severity.CRITICAL
     )
     ```
 
@@ -24,7 +24,7 @@
       check-id: no-null-email
       columns:
         - email
-      severity: error
+      severity: critical
     ```
 
 ## Typical Use Cases

--- a/docs/built_in_checks/checks/null/null_check.md
+++ b/docs/built_in_checks/checks/null/null_check.md
@@ -1,8 +1,24 @@
+---
+wide: true
+---
+
 # Null Check
 
-**Check**: `null-check`
+**Check name**: `null-check` · **Type**: row-level · **Config**: `NullCheckConfig`
 
-**Purpose**: Ensures that the specified columns contain no null values. Use this check to enforce completeness of mandatory fields and prevent incomplete records from entering downstream processes.
+Flags any record that contains a null value in one or more of the configured
+columns. Use it to enforce completeness of mandatory fields and keep incomplete
+records out of downstream processing.
+
+## Parameters
+
+| Parameter  | Type        | Required | Default    | Description                                             |
+| ---------- | ----------- | -------- | ---------- | ------------------------------------------------------- |
+| `check_id` | `str`       | yes      | —          | Unique identifier for this check within the `CheckSet`. |
+| `columns`  | `list[str]` | yes      | —          | Columns that must be non-null. YAML key: `columns`.     |
+| `severity` | `Severity`  | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.    |
+
+## Usage
 
 === "Python"
 
@@ -13,7 +29,7 @@
     NullCheckConfig(
         check_id="no-null-email",
         columns=["email"],
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -27,11 +43,95 @@
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Enforce completeness of primary keys, foreign keys, and business-critical attributes.
+- **OR semantics across columns.** A record fails if _any_ of the listed columns
+  is null. To require each column independently with its own severity or error
+  id, define one `null-check` per column instead.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`;
+  passing rows are unaffected. With the default severity, a failure sets
+  `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist in the
+  DataFrame, the check raises `MissingColumnError` at validation time rather than
+  silently passing.
+
+## Example
+
+Given a DataFrame with one null `email`, both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import NullCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": None},
+        {"id": 3, "email": "c@example.com"},
+    ])
+
+    check_set = CheckSet().add_check(
+        NullCheckConfig(check_id="no-null-email", columns=["email"])
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": None},
+        {"id": 3, "email": "c@example.com"},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+The failing row is returned with its error metadata:
+
+```text
++-----+---+--------------------------------------+----------+--------------------------+
+|email|id |_dq_errors                            |_dq_passed|_dq_validation_ts         |
++-----+---+--------------------------------------+----------+--------------------------+
+|NULL |2  |[{NullCheck, no-null-email, critical}]|false     |2026-01-01 00:00:00.000000|
++-----+---+--------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Enforce completeness of primary keys, foreign keys, and business-critical
+  attributes.
 - Prevent incomplete records from reaching downstream transformations or reports.
 - Detect data gaps introduced by upstream extraction or ingestion failures.
+
+## Related checks
+
+- [Not Null Check](not_null_check.md) — the inverse assertion for columns that
+  are expected to be null.
+- [Exactly One Not Null Check](exactly_one_not_null_check.md) — require exactly
+  one of several columns to be populated.
+- [Completeness Ratio Check](../completeness/completeness_ratio_check.md) —
+  dataset-level tolerance for a share of nulls instead of a hard per-row rule.
 
 ---
 

--- a/docs/built_in_checks/checks/numeric/numeric_between_check.md
+++ b/docs/built_in_checks/checks/numeric/numeric_between_check.md
@@ -1,17 +1,27 @@
-# Numeric Between
+---
+wide: true
+---
 
-**Check**: `numeric-between-check`
+# Numeric Between Check
 
-**Purpose**: Validates that values in numeric columns fall within a defined range. A row fails if any selected column contains a value outside the configured bounds.
+**Check name**: `numeric-between-check` · **Type**: row-level · **Config**: `NumericBetweenCheckConfig`
 
-Use the `inclusive` parameter to control boundary behavior:
+Flags any record whose value in one of the configured columns falls outside a
+`[min, max]` range. Use it to constrain values to a valid interval, such as a
+percentage between 0 and 100 or a plausible sensor reading.
 
-| Value                      | Behavior                                   |
-| -------------------------- | ------------------------------------------ |
-| `[false, false]` (default) | strictly between: `min < value < max`      |
-| `[true, false]`            | include lower bound: `min <= value < max`  |
-| `[false, true]`            | include upper bound: `min < value <= max`  |
-| `[true, true]`             | include both bounds: `min <= value <= max` |
+## Parameters
+
+| Parameter   | Type                | Required | Default          | Description                                                           |
+| ----------- | ------------------- | -------- | ---------------- | --------------------------------------------------------------------- |
+| `check_id`  | `str`               | yes      | —                | Unique identifier for this check within the `CheckSet`.               |
+| `columns`   | `list[str]`         | yes      | —                | Numeric columns to compare against the range. YAML key: `columns`.    |
+| `min_value` | `float \| int`      | yes      | —                | Lower bound of the range. YAML key: `min-value`.                      |
+| `max_value` | `float \| int`      | yes      | —                | Upper bound of the range. YAML key: `max-value`.                      |
+| `inclusive` | `tuple[bool, bool]` | no       | `(False, False)` | Inclusivity of the lower and upper bound respectively (see Behavior). |
+| `severity`  | `Severity`          | no       | `CRITICAL`       | `CRITICAL` fails the row; `WARNING` only records it.                  |
+
+## Usage
 
 === "Python"
 
@@ -20,12 +30,12 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     NumericBetweenCheckConfig(
-        check_id="discount-within-valid-range",
-        columns=["discount"],
-        min_value=0.0,
-        max_value=100.0,
+        check_id="temp-range",
+        columns=["temp"],
+        min_value=0,
+        max_value=100,
         inclusive=(True, True),
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -33,20 +43,113 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: numeric-between-check
-      check-id: discount-within-valid-range
+      check-id: temp-range
       columns:
-        - discount
-      min-value: 0.0
-      max-value: 100.0
+        - temp
+      min-value: 0
+      max-value: 100
       inclusive: [true, true]
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Validate that percentages, ratios, or scores fall within their expected range (e.g., 0–100).
-- Enforce physical or business-defined constraints on numeric measurements.
-- Detect outliers or erroneous values that fall outside acceptable thresholds.
+- **`inclusive` is a `(lower, upper)` pair and defaults to `(False, False)`** —
+  i.e. strictly between. Each bound is controlled independently:
+
+  | `inclusive`      | Passing range         |
+  | ---------------- | --------------------- |
+  | `(False, False)` | `min < value < max`   |
+  | `(True, False)`  | `min <= value < max`  |
+  | `(False, True)`  | `min < value <= max`  |
+  | `(True, True)`   | `min <= value <= max` |
+
+- **Validated at config time.** `min_value` must not be greater than `max_value`,
+  or the config raises an `InvalidCheckConfigurationError` before any data is
+  touched.
+- **OR semantics across columns.** With multiple columns, a record fails if
+  _any_ of them lies outside the range.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`; with
+  the default severity, a failure sets `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist, the check
+  raises `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `temp` within `[0, 100]` (both bounds inclusive), both styles produce
+the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import NumericBetweenCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "temp": 50},
+        {"id": 2, "temp": -5},
+        {"id": 3, "temp": 120},
+    ])
+
+    check_set = CheckSet().add_check(
+        NumericBetweenCheckConfig(
+            check_id="temp-range", columns=["temp"], min_value=0, max_value=100, inclusive=(True, True)
+        )
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "temp": 50},
+        {"id": 2, "temp": -5},
+        {"id": 3, "temp": 120},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Both out-of-range rows fail; the in-range row passes:
+
+```text
++---+----+---------------------------------------------+----------+--------------------------+
+|id |temp|_dq_errors                                   |_dq_passed|_dq_validation_ts         |
++---+----+---------------------------------------------+----------+--------------------------+
+|2  |-5  |[{NumericBetweenCheck, temp-range, critical}]|false     |2026-01-01 00:00:00.000000|
+|3  |120 |[{NumericBetweenCheck, temp-range, critical}]|false     |2026-01-01 00:00:00.000000|
++---+----+---------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Constrain percentages, ratios, or scores to their valid interval (e.g. 0–100).
+- Enforce physical or business-defined bounds on measurements.
+- Detect outliers that fall outside an acceptable range.
+
+## Related checks
+
+- [Numeric Min Check](numeric_min_check.md) — enforce only a lower bound.
+- [Numeric Max Check](numeric_max_check.md) — enforce only an upper bound.
 
 ---
 

--- a/docs/built_in_checks/checks/numeric/numeric_max_check.md
+++ b/docs/built_in_checks/checks/numeric/numeric_max_check.md
@@ -1,13 +1,26 @@
-# Numeric Max
+---
+wide: true
+---
 
-**Check**: `numeric-max-check`
+# Numeric Max Check
 
-**Purpose**: Validates that values in numeric columns do not exceed a defined maximum. A row fails if any selected column contains a value greater than `max_value`.
+**Check name**: `numeric-max-check` · **Type**: row-level · **Config**: `NumericMaxCheckConfig`
 
-Use the `inclusive` parameter to control boundary behavior:
+Flags any record whose value in one of the configured columns exceeds a maximum
+threshold. Use it to enforce upper bounds such as a percentage capped at 100, a
+maximum order quantity, or a plausible measurement ceiling.
 
-- `inclusive: false` (default) — `value < max_value`
-- `inclusive: true` — `value <= max_value`
+## Parameters
+
+| Parameter   | Type           | Required | Default    | Description                                                            |
+| ----------- | -------------- | -------- | ---------- | ---------------------------------------------------------------------- |
+| `check_id`  | `str`          | yes      | —          | Unique identifier for this check within the `CheckSet`.                |
+| `columns`   | `list[str]`    | yes      | —          | Numeric columns to compare against the threshold. YAML key: `columns`. |
+| `max_value` | `float \| int` | yes      | —          | The upper bound. YAML key: `max-value`.                                |
+| `inclusive` | `bool`         | no       | `False`    | Whether `max_value` itself is allowed (see Behavior).                  |
+| `severity`  | `Severity`     | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                   |
+
+## Usage
 
 === "Python"
 
@@ -16,11 +29,11 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     NumericMaxCheckConfig(
-        check_id="discount-not-above-100",
-        columns=["discount"],
-        max_value=100.0,
+        check_id="max-score",
+        columns=["score"],
+        max_value=100,
         inclusive=True,
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -28,19 +41,98 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: numeric-max-check
-      check-id: discount-not-above-100
+      check-id: max-score
       columns:
-        - discount
-      max-value: 100.0
+        - score
+      max-value: 100
       inclusive: true
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure prices, quantities, or KPI values do not exceed defined upper limits.
-- Validate that percentages or scores stay at or below 100.
-- Detect data entry errors or system anomalies producing out-of-range values.
+- **`inclusive` controls the boundary, and defaults to `False`.** With
+  `inclusive=True`, a value equal to `max_value` **passes** (`value <= max_value`
+  is required). With the default `inclusive=False`, the boundary value itself
+  **fails** (`value < max_value` is required). Set `inclusive=True` when the
+  threshold should be an allowed value — this is the most common intent.
+- **OR semantics across columns.** With multiple columns, a record fails if
+  _any_ of them exceeds the threshold.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`; with
+  the default severity, a failure sets `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist, the check
+  raises `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `score <= 100` (`inclusive=True`), both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import NumericMaxCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "score": 90},
+        {"id": 2, "score": 105},
+    ])
+
+    check_set = CheckSet().add_check(
+        NumericMaxCheckConfig(check_id="max-score", columns=["score"], max_value=100, inclusive=True)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "score": 90},
+        {"id": 2, "score": 105},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the out-of-range row fails:
+
+```text
++---+-----+----------------------------------------+----------+--------------------------+
+|id |score|_dq_errors                              |_dq_passed|_dq_validation_ts         |
++---+-----+----------------------------------------+----------+--------------------------+
+|2  |105  |[{NumericMaxCheck, max-score, critical}]|false     |2026-01-01 00:00:00.000000|
++---+-----+----------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Cap percentages or scores at a known ceiling (e.g. 100).
+- Enforce a maximum order quantity or transaction amount.
+- Detect data entry errors or anomalies producing implausibly large values.
+
+## Related checks
+
+- [Numeric Min Check](numeric_min_check.md) — enforce a lower bound.
+- [Numeric Between Check](numeric_between_check.md) — enforce both bounds at once.
 
 ---
 

--- a/docs/built_in_checks/checks/numeric/numeric_min_check.md
+++ b/docs/built_in_checks/checks/numeric/numeric_min_check.md
@@ -1,13 +1,26 @@
-# Numeric Min
+---
+wide: true
+---
 
-**Check**: `numeric-min-check`
+# Numeric Min Check
 
-**Purpose**: Validates that values in numeric columns are not below a defined minimum. A row fails if any selected column contains a value less than `min_value`.
+**Check name**: `numeric-min-check` · **Type**: row-level · **Config**: `NumericMinCheckConfig`
 
-Use the `inclusive` parameter to control boundary behavior:
+Flags any record whose value in one of the configured columns falls below a
+minimum threshold. Use it to enforce lower bounds such as a minimum age, a
+non-negative balance, or an acceptable measurement floor.
 
-- `inclusive: false` (default) — `value > min_value`
-- `inclusive: true` — `value >= min_value`
+## Parameters
+
+| Parameter   | Type           | Required | Default    | Description                                                            |
+| ----------- | -------------- | -------- | ---------- | ---------------------------------------------------------------------- |
+| `check_id`  | `str`          | yes      | —          | Unique identifier for this check within the `CheckSet`.                |
+| `columns`   | `list[str]`    | yes      | —          | Numeric columns to compare against the threshold. YAML key: `columns`. |
+| `min_value` | `float \| int` | yes      | —          | The lower bound. YAML key: `min-value`.                                |
+| `inclusive` | `bool`         | no       | `False`    | Whether `min_value` itself is allowed (see Behavior).                  |
+| `severity`  | `Severity`     | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                   |
+
+## Usage
 
 === "Python"
 
@@ -16,11 +29,11 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     NumericMinCheckConfig(
-        check_id="price-not-negative",
-        columns=["price", "discount"],
-        min_value=0.0,
+        check_id="min-age",
+        columns=["age"],
+        min_value=18,
         inclusive=True,
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -28,20 +41,100 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: numeric-min-check
-      check-id: price-not-negative
+      check-id: min-age
       columns:
-        - price
-        - discount
-      min-value: 0.0
+        - age
+      min-value: 18
       inclusive: true
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure monetary amounts, quantities, or measurements are non-negative.
-- Enforce minimum threshold requirements for KPIs or scoring metrics.
-- Detect corrupted or invalid numeric values below the physically meaningful range.
+- **`inclusive` controls the boundary, and defaults to `False`.** With
+  `inclusive=True`, a value equal to `min_value` **passes** (`value >= min_value`
+  is required). With the default `inclusive=False`, the boundary value itself
+  **fails** (`value > min_value` is required). Set `inclusive=True` when the
+  threshold should be an allowed value — this is the most common intent.
+- **OR semantics across columns.** With multiple columns, a record fails if
+  _any_ of them is below the threshold.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`; with
+  the default severity, a failure sets `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist, the check
+  raises `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `age >= 18` (`inclusive=True`), both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import NumericMinCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "age": 25},
+        {"id": 2, "age": 17},
+        {"id": 3, "age": 18},
+    ])
+
+    check_set = CheckSet().add_check(
+        NumericMinCheckConfig(check_id="min-age", columns=["age"], min_value=18, inclusive=True)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "age": 25},
+        {"id": 2, "age": 17},
+        {"id": 3, "age": 18},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the underage row fails (`age = 18` passes because the bound is inclusive):
+
+```text
++---+---+--------------------------------------+----------+--------------------------+
+|age|id |_dq_errors                            |_dq_passed|_dq_validation_ts         |
++---+---+--------------------------------------+----------+--------------------------+
+|17 |2  |[{NumericMinCheck, min-age, critical}]|false     |2026-01-01 00:00:00.000000|
++---+---+--------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Enforce a minimum age, quantity, or order amount.
+- Reject negative values where only non-negative numbers are valid.
+- Guard a measurement or score against an unacceptable floor.
+
+## Related checks
+
+- [Numeric Max Check](numeric_max_check.md) — enforce an upper bound.
+- [Numeric Between Check](numeric_between_check.md) — enforce both bounds at once.
 
 ---
 

--- a/docs/built_in_checks/checks/schema/column_presence_check.md
+++ b/docs/built_in_checks/checks/schema/column_presence_check.md
@@ -1,8 +1,24 @@
-# Column Presence
+---
+wide: true
+---
 
-**Check**: `column-presence-check`
+# Column Presence Check
 
-**Purpose**: Validates that all required columns are present in the DataFrame, regardless of data type. Use this as an early schema guard to prevent downstream failures caused by missing columns.
+**Check name**: `column-presence-check` · **Type**: aggregate · **Config**: `ColumnPresenceCheckConfig`
+
+Validates that all required columns are present in the DataFrame schema, ignoring
+their types and any extra columns. Use it as a lightweight contract on the shape
+of an input.
+
+## Parameters
+
+| Parameter          | Type        | Required | Default    | Description                                               |
+| ------------------ | ----------- | -------- | ---------- | --------------------------------------------------------- |
+| `check_id`         | `str`       | yes      | —          | Unique identifier for this check within the `CheckSet`.   |
+| `required_columns` | `list[str]` | yes      | —          | Columns that must exist. YAML key: `required-columns`.    |
+| `severity`         | `Severity`  | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports. |
+
+## Usage
 
 === "Python"
 
@@ -11,9 +27,9 @@
     from sparkdq.core import Severity
 
     ColumnPresenceCheckConfig(
-        check_id="required-columns-present",
-        required_columns=["id", "event_timestamp", "status"],
-        severity=Severity.CRITICAL
+        check_id="required-cols",
+        required_columns=["id", "email"],
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -21,19 +37,85 @@
 
     ```yaml
     - check: column-presence-check
-      check-id: required-columns-present
+      check-id: required-cols
       required-columns:
         - id
-        - event_timestamp
-        - status
+        - email
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Detect schema regressions where key columns are accidentally dropped by upstream producers.
-- Validate that technical metadata columns such as `event_timestamp` or `partition_key` are present.
-- Prevent silent failures in transformation logic that depends on specific column names.
+- **Presence only.** Checks that each required column exists; it does not inspect
+  types or reject extra columns (use the [Schema Check](schema_check.md) for that).
+- **A critical failure fails the batch.** A failing `CRITICAL` aggregate marks
+  _every_ row `_dq_passed = False`. A `WARNING` failure is reported only.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict lists `missing_columns`.
+
+## Example
+
+Requiring `id` and `email` on a DataFrame missing `email`, the check fails.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import ColumnPresenceCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": 1, "name": "Alice"}])
+
+    check_set = CheckSet().add_check(
+        ColumnPresenceCheckConfig(check_id="required-cols", required_columns=["id", "email"])
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": 1, "name": "Alice"}])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result lists the missing column:
+
+```text
+required-cols False {'missing_columns': ['email']}
+```
+
+## Typical use cases
+
+- Assert a minimal input contract before processing.
+- Fail fast when an upstream feed drops an expected column.
+- Guard notebooks or jobs against schema drift.
+
+## Related checks
+
+- [Schema Check](schema_check.md) — also validate column types and reject unexpected columns.
 
 ---
 

--- a/docs/built_in_checks/checks/schema/schema_check.md
+++ b/docs/built_in_checks/checks/schema/schema_check.md
@@ -1,17 +1,25 @@
+---
+wide: true
+---
+
 # Schema Check
 
-**Check**: `schema-check`
+**Check name**: `schema-check` · **Type**: aggregate · **Config**: `SchemaCheckConfig`
 
-**Purpose**: Validates that the DataFrame matches an expected schema in terms of column names and Spark data types. Optionally enforces strict matching to reject unexpected additional columns.
+Validates that the DataFrame matches an expected schema — the required columns
+are present with the expected Spark types, and (in strict mode) no unexpected
+columns exist. Use it as a full structural contract on an input.
 
-## Supported Data Types
+## Parameters
 
-The following Spark types are supported and must be specified as lowercase strings:
+| Parameter         | Type             | Required | Default    | Description                                                              |
+| ----------------- | ---------------- | -------- | ---------- | ------------------------------------------------------------------------ |
+| `check_id`        | `str`            | yes      | —          | Unique identifier for this check within the `CheckSet`.                  |
+| `expected_schema` | `dict[str, str]` | yes      | —          | Mapping of column name → Spark type string. YAML key: `expected-schema`. |
+| `strict`          | `bool`           | no       | `True`     | If `True`, extra columns not in the schema fail the check.               |
+| `severity`        | `Severity`       | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports.                |
 
-`string`, `boolean`, `int`, `bigint`, `float`, `double`, `date`, `timestamp`, `binary`, `array`, `map`, `struct`, `decimal(precision, scale)` — e.g., `decimal(10,2)`
-
-!!! important
-For `decimal` types, both precision and scale must be specified inside parentheses. Formats such as `integer` or `decimal(10.2)` are not accepted.
+## Usage
 
 === "Python"
 
@@ -20,15 +28,10 @@ For `decimal` types, both precision and scale must be specified inside parenthes
     from sparkdq.core import Severity
 
     SchemaCheckConfig(
-        check_id="enforce-schema-contract",
-        expected_schema={
-            "id": "int",
-            "name": "string",
-            "amount": "decimal(10,2)",
-            "created_at": "timestamp"
-        },
+        check_id="input-schema",
+        expected_schema={"id": "bigint", "name": "string", "email": "string"},
         strict=True,
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -36,21 +39,95 @@ For `decimal` types, both precision and scale must be specified inside parenthes
 
     ```yaml
     - check: schema-check
-      check-id: enforce-schema-contract
+      check-id: input-schema
       expected-schema:
-        id: int
+        id: bigint
         name: string
-        amount: decimal(10,2)
-        created_at: timestamp
+        email: string
       strict: true
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Enforce schema contracts between ingestion, transformation, and consumption stages.
-- Detect missing, renamed, or type-changed columns introduced by upstream schema evolution.
-- Prevent silent data corruption caused by implicit type casting on incorrect column types.
+- **Three failure modes.** The check fails on any missing column, any type
+  mismatch, or — when `strict=True` — any unexpected extra column.
+- **Type strings are Spark types.** Use Spark SQL type names such as `bigint`,
+  `string`, `double`, `timestamp`. They must match the DataFrame's actual types
+  exactly.
+- **`strict` defaults to `True`.** Set `strict=False` to allow additional columns
+  beyond the expected schema.
+- **A critical failure fails the batch.** A failing `CRITICAL` aggregate marks
+  _every_ row `_dq_passed = False`. A `WARNING` failure is reported only.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict reports `missing_columns`, `type_mismatches`, and `unexpected_columns`.
+
+## Example
+
+Expecting an `email` column that is absent, the check fails.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import SchemaCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": 1, "name": "Alice"}])
+
+    check_set = CheckSet().add_check(
+        SchemaCheckConfig(
+            check_id="input-schema",
+            expected_schema={"id": "bigint", "name": "string", "email": "string"},
+        )
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([{"id": 1, "name": "Alice"}])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result breaks the failure down by category:
+
+```text
+input-schema False {'missing_columns': ['email'], 'type_mismatches': {}, 'unexpected_columns': []}
+```
+
+## Typical use cases
+
+- Enforce a full input contract (columns + types) before processing.
+- Detect schema drift such as renamed columns or changed types.
+- Reject unexpected extra columns in strict pipelines.
+
+## Related checks
+
+- [Column Presence Check](column_presence_check.md) — a lighter check for column existence only.
 
 ---
 

--- a/docs/built_in_checks/checks/strings/regex_match_check.md
+++ b/docs/built_in_checks/checks/strings/regex_match_check.md
@@ -1,10 +1,27 @@
+---
+wide: true
+---
+
 # Regex Match Check
 
-**Check**: `regex-match-check`
+**Check name**: `regex-match-check` · **Type**: row-level · **Config**: `RegexMatchCheckConfig`
 
-**Purpose**: Validates that string values in a column match a given regular expression pattern. Use this to enforce format compliance for structured fields such as email addresses, identifiers, or standardized codes.
+Flags any record whose string value in the configured column does not match a
+regular expression. Use it to enforce format compliance for structured fields
+such as email addresses, identifiers, or standardized codes.
 
-!!! note - Null values are skipped by default. Set `treat_null_as_failure: true` to treat them as invalid. - Pattern matching is case-sensitive by default. Use `ignore_case: true` for case-insensitive matching.
+## Parameters
+
+| Parameter               | Type       | Required | Default    | Description                                                         |
+| ----------------------- | ---------- | -------- | ---------- | ------------------------------------------------------------------- |
+| `check_id`              | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.             |
+| `column`                | `str`      | yes      | —          | The string column to validate (a single column).                    |
+| `pattern`               | `str`      | yes      | —          | The regular expression the value must match (Spark `rlike` syntax). |
+| `ignore_case`           | `bool`     | no       | `False`    | Case-insensitive matching. YAML key: `ignore-case`.                 |
+| `treat_null_as_failure` | `bool`     | no       | `False`    | Treat nulls as failures. YAML key: `treat-null-as-failure`.         |
+| `severity`              | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                |
+
+## Usage
 
 === "Python"
 
@@ -13,12 +30,12 @@
     from sparkdq.core import Severity
 
     RegexMatchCheckConfig(
-        check_id="valid-email-format",
+        check_id="email-format",
         column="email",
-        pattern=r"^[\w\.-]+@[\w\.-]+\.\w+$",
+        pattern=r"^[^@]+@[^@]+\.[^@]+$",
         ignore_case=True,
         treat_null_as_failure=False,
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -26,19 +43,98 @@
 
     ```yaml
     - check: regex-match-check
-      check-id: valid-email-format
+      check-id: email-format
       column: email
-      pattern: "^[\\w\\.-]+@[\\w\\.-]+\\.\\w+$"
+      pattern: "^[^@]+@[^@]+\\.[^@]+$"
       ignore-case: true
       treat-null-as-failure: false
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
+
+- **Null handling is configurable.** By default (`treat_null_as_failure=False`),
+  null values are **skipped** and pass. Set `treat_null_as_failure=True` to fail
+  nulls as well.
+- **Case sensitivity.** Matching is case-sensitive unless `ignore_case=True`,
+  which applies the `(?i)` flag to the pattern.
+- **Match semantics.** A row fails when a non-null value does _not_ match the
+  pattern. The pattern uses Spark's `rlike` (Java regex) syntax; in YAML,
+  backslashes must be escaped (`\\.`).
+- **Single column.** This check takes one `column`.
+- **Missing column raises.** If the column does not exist, the check raises
+  `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `email` to look like an address, both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import RegexMatchCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": "nope"},
+    ])
+
+    check_set = CheckSet().add_check(
+        RegexMatchCheckConfig(check_id="email-format", column="email", pattern=r"^[^@]+@[^@]+\.[^@]+$")
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": "nope"},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the malformed value fails:
+
+```text
++-----+---+-------------------------------------------+----------+--------------------------+
+|email|id |_dq_errors                                 |_dq_passed|_dq_validation_ts         |
++-----+---+-------------------------------------------+----------+--------------------------+
+|nope |2  |[{RegexMatchCheck, email-format, critical}]|false     |2026-01-01 00:00:00.000000|
++-----+---+-------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
 
 - Validate format compliance for email addresses, phone numbers, or postal codes.
-- Enforce structured identifier patterns such as `AB-12345` or `ISO-8601` date strings.
+- Enforce structured identifier patterns such as `AB-12345`.
 - Detect malformed or free-text values in fields that require a standardized format.
+
+## Related checks
+
+- [String Between Length Check](string_between_length.md) — constrain length rather than format.
+- [Is Contained In Check](../contained_in/is_contained_in_check.md) — restrict to a fixed set of allowed values.
 
 ---
 

--- a/docs/built_in_checks/checks/strings/string_between_length.md
+++ b/docs/built_in_checks/checks/strings/string_between_length.md
@@ -1,17 +1,27 @@
+---
+wide: true
+---
+
 # String Length Between Check
 
-**Check**: `string-length-between-check`
+**Check name**: `string-length-between-check` · **Type**: row-level · **Config**: `StringLengthBetweenCheckConfig`
 
-**Purpose**: Validates that non-null string values in a column have a length within a specified range. Use this to ensure strings are neither too short nor too long — useful for validating user input, enforcing field formatting, or detecting truncation issues.
+Flags any record whose string value in the configured column has a length outside
+a `[min, max]` range. Use it to keep values within a bounded format — neither too
+short nor too long.
 
-!!! note
-Null values are treated as valid and are not evaluated by this check.
+## Parameters
 
-Use the `inclusive` parameter to control boundary behavior:
+| Parameter    | Type                | Required | Default        | Description                                                |
+| ------------ | ------------------- | -------- | -------------- | ---------------------------------------------------------- |
+| `check_id`   | `str`               | yes      | —              | Unique identifier for this check within the `CheckSet`.    |
+| `column`     | `str`               | yes      | —              | The string column to validate (a single column).           |
+| `min_length` | `int`               | yes      | —              | Lower length bound; must be `> 0`. YAML key: `min-length`. |
+| `max_length` | `int`               | yes      | —              | Upper length bound. YAML key: `max-length`.                |
+| `inclusive`  | `tuple[bool, bool]` | no       | `(True, True)` | Inclusivity of the lower and upper bound respectively.     |
+| `severity`   | `Severity`          | no       | `CRITICAL`     | `CRITICAL` fails the row; `WARNING` only records it.       |
 
-- `inclusive: [true, false]` → `min_length <= len(value) < max_length`
-- `inclusive: [false, true]` → `min_length < len(value) <= max_length`
-- `inclusive: [true, true]` → `min_length <= len(value) <= max_length`
+## Usage
 
 === "Python"
 
@@ -20,12 +30,12 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     StringLengthBetweenCheckConfig(
-        check_id="zone-name-length",
-        column="zone_name",
-        min_length=3,
-        max_length=50,
+        check_id="tag-len",
+        column="tag",
+        min_length=2,
+        max_length=4,
         inclusive=(True, True),
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -33,19 +43,110 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: string-length-between-check
-      check-id: zone-name-length
-      column: zone_name
-      min-length: 3
-      max-length: 50
+      check-id: tag-len
+      column: tag
+      min-length: 2
+      max-length: 4
       inclusive: [true, true]
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Enforce minimum and maximum length constraints on user-entered text fields.
-- Detect truncated or excessively long values introduced by integration or migration issues.
-- Validate that identifiers or codes conform to a known fixed-length or bounded-length format.
+- **Null values pass.** Only non-null strings are evaluated.
+- **`inclusive` is a `(lower, upper)` pair and defaults to `(True, True)`** — i.e.
+  both bounds are allowed by default. Each bound is controlled independently:
+
+  | `inclusive`      | Passing length range   |
+  | ---------------- | ---------------------- |
+  | `(True, True)`   | `min <= length <= max` |
+  | `(True, False)`  | `min <= length < max`  |
+  | `(False, True)`  | `min < length <= max`  |
+  | `(False, False)` | `min < length < max`   |
+
+- **Single column.** This check takes one `column`.
+- **`min_length` must be positive**, or the config raises
+  `InvalidCheckConfigurationError` before any data is touched.
+- **Missing column raises.** If the column does not exist, the check raises
+  `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `tag` length within `[2, 4]` (both bounds inclusive), both styles
+produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import StringLengthBetweenCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "tag": "ab"},
+        {"id": 2, "tag": "a"},
+        {"id": 3, "tag": "abcde"},
+    ])
+
+    check_set = CheckSet().add_check(
+        StringLengthBetweenCheckConfig(
+            check_id="tag-len", column="tag", min_length=2, max_length=4, inclusive=(True, True)
+        )
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "tag": "ab"},
+        {"id": 2, "tag": "a"},
+        {"id": 3, "tag": "abcde"},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+The too-short and too-long values fail; the in-range value passes:
+
+```text
++---+-----+-----------------------------------------------+----------+--------------------------+
+|id |tag  |_dq_errors                                     |_dq_passed|_dq_validation_ts         |
++---+-----+-----------------------------------------------+----------+--------------------------+
+|2  |a    |[{StringLengthBetweenCheck, tag-len, critical}]|false     |2026-01-01 00:00:00.000000|
+|3  |abcde|[{StringLengthBetweenCheck, tag-len, critical}]|false     |2026-01-01 00:00:00.000000|
++---+-----+-----------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Enforce minimum and maximum length on user-entered text fields.
+- Detect truncated or overlong values from integration or migration issues.
+- Validate that identifiers or codes conform to a bounded-length format.
+
+## Related checks
+
+- [String Min Length Check](string_min_length.md) — enforce only a lower length bound.
+- [String Max Length Check](string_max_length.md) — enforce only an upper length bound.
+- [Regex Match Check](regex_match_check.md) — validate the value's format.
 
 ---
 

--- a/docs/built_in_checks/checks/strings/string_max_length.md
+++ b/docs/built_in_checks/checks/strings/string_max_length.md
@@ -1,16 +1,26 @@
+---
+wide: true
+---
+
 # String Max Length Check
 
-**Check**: `string-max-length-check`
+**Check name**: `string-max-length-check` · **Type**: row-level · **Config**: `StringMaxLengthCheckConfig`
 
-**Purpose**: Validates that non-null string values in a column do not exceed a defined maximum length. Use this to detect overflow, incorrectly padded, or malformed string data.
+Flags any record whose string value in the configured column is longer than a
+maximum length. Use it to catch overflowing, padded, or malformed values, or to
+enforce limits aligned with a database column or UI field.
 
-!!! note
-Null values are treated as valid and are not evaluated by this check.
+## Parameters
 
-Use the `inclusive` parameter to control boundary behavior:
+| Parameter    | Type       | Required | Default    | Description                                             |
+| ------------ | ---------- | -------- | ---------- | ------------------------------------------------------- |
+| `check_id`   | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`. |
+| `column`     | `str`      | yes      | —          | The string column to validate (a single column).        |
+| `max_length` | `int`      | yes      | —          | Maximum length. YAML key: `max-length`.                 |
+| `inclusive`  | `bool`     | no       | `True`     | Whether `max_length` itself is allowed (see Behavior).  |
+| `severity`   | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.    |
 
-- `inclusive: true` (default) — `len(value) <= max_length`
-- `inclusive: false` — `len(value) < max_length`
+## Usage
 
 === "Python"
 
@@ -19,11 +29,11 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     StringMaxLengthCheckConfig(
-        check_id="zone-name-max-length",
-        column="zone_name",
-        max_length=50,
+        check_id="max-name",
+        column="name",
+        max_length=5,
         inclusive=True,
-        severity=Severity.WARNING
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -31,18 +41,95 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: string-max-length-check
-      check-id: zone-name-max-length
-      column: zone_name
-      max-length: 50
+      check-id: max-name
+      column: name
+      max-length: 5
       inclusive: true
-      severity: warning
+      severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Detect padded or overlong string values produced by integration bugs or data entry errors.
-- Enforce length constraints aligned with database schema column definitions or UI field limits.
-- Identify legacy fields carrying excess content that exceeds the expected value format.
+- **Null values pass.** Only non-null strings are evaluated; a null in the column
+  never fails this check.
+- **`inclusive` controls the boundary, and defaults to `True`.** With the default,
+  a string of exactly `max_length` characters **passes** (`length <= max_length`).
+  With `inclusive=False`, that boundary length **fails** (`length < max_length`).
+- **Single column.** This check takes one `column`.
+- **Missing column raises.** If the column does not exist, the check raises
+  `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `name` to be at most 5 characters, both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import StringMaxLengthCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "name": "Bob"},
+        {"id": 2, "name": "Bartholomew"},
+    ])
+
+    check_set = CheckSet().add_check(
+        StringMaxLengthCheckConfig(check_id="max-name", column="name", max_length=5)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "name": "Bob"},
+        {"id": 2, "name": "Bartholomew"},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the overlong value fails:
+
+```text
++---+-----------+--------------------------------------------+----------+--------------------------+
+|id |name       |_dq_errors                                  |_dq_passed|_dq_validation_ts         |
++---+-----------+--------------------------------------------+----------+--------------------------+
+|2  |Bartholomew|[{StringMaxLengthCheck, max-name, critical}]|false     |2026-01-01 00:00:00.000000|
++---+-----------+--------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Detect padded or overlong values from integration bugs or data entry errors.
+- Enforce length limits aligned with database schema or UI field constraints.
+- Identify legacy fields carrying excess content.
+
+## Related checks
+
+- [String Min Length Check](string_min_length.md) — enforce a lower length bound.
+- [String Between Length Check](string_between_length.md) — enforce both length bounds.
+- [Regex Match Check](regex_match_check.md) — validate the value's format.
 
 ---
 

--- a/docs/built_in_checks/checks/strings/string_min_length.md
+++ b/docs/built_in_checks/checks/strings/string_min_length.md
@@ -1,16 +1,26 @@
+---
+wide: true
+---
+
 # String Min Length Check
 
-**Check**: `string-min-length-check`
+**Check name**: `string-min-length-check` · **Type**: row-level · **Config**: `StringMinLengthCheckConfig`
 
-**Purpose**: Validates that non-null string values in a column meet a minimum length requirement. Use this to detect truncated, malformed, or unexpectedly short string data.
+Flags any record whose string value in the configured column is shorter than a
+minimum length. Use it to catch truncated, malformed, or unexpectedly short
+values such as codes or identifiers.
 
-!!! note
-Null values are treated as valid and are not evaluated by this check.
+## Parameters
 
-Use the `inclusive` parameter to control boundary behavior:
+| Parameter    | Type       | Required | Default    | Description                                             |
+| ------------ | ---------- | -------- | ---------- | ------------------------------------------------------- |
+| `check_id`   | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`. |
+| `column`     | `str`      | yes      | —          | The string column to validate (a single column).        |
+| `min_length` | `int`      | yes      | —          | Minimum length; must be `> 0`. YAML key: `min-length`.  |
+| `inclusive`  | `bool`     | no       | `True`     | Whether `min_length` itself is allowed (see Behavior).  |
+| `severity`   | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.    |
 
-- `inclusive: true` (default) — `len(value) >= min_length`
-- `inclusive: false` — `len(value) > min_length`
+## Usage
 
 === "Python"
 
@@ -19,11 +29,11 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     StringMinLengthCheckConfig(
-        check_id="zone-name-min-length",
-        column="zone_name",
+        check_id="min-code",
+        column="code",
         min_length=3,
         inclusive=True,
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -31,18 +41,100 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: string-min-length-check
-      check-id: zone-name-min-length
-      column: zone_name
+      check-id: min-code
+      column: code
       min-length: 3
       inclusive: true
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure that identifiers, codes, or names are not shorter than the minimum meaningful length.
-- Detect truncated values caused by data extraction or encoding issues.
-- Enforce minimum content requirements on free-text or structured string fields.
+- **Null values pass.** Only non-null strings are evaluated; a null in the column
+  never fails this check. Combine with a [Null Check](../null/null_check.md) if the
+  column must also be populated.
+- **`inclusive` controls the boundary, and defaults to `True`.** With the default,
+  a string of exactly `min_length` characters **passes** (`length >= min_length`).
+  With `inclusive=False`, that boundary length **fails** (`length > min_length`).
+- **Single column.** Unlike the numeric checks, this check takes one `column`.
+- **`min_length` must be positive**, or the config raises
+  `InvalidCheckConfigurationError` before any data is touched.
+- **Missing column raises.** If the column does not exist, the check raises
+  `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `code` to be at least 3 characters, both styles produce the same result.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import StringMinLengthCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "code": "abc"},
+        {"id": 2, "code": "ab"},
+        {"id": 3, "code": None},
+    ])
+
+    check_set = CheckSet().add_check(
+        StringMinLengthCheckConfig(check_id="min-code", column="code", min_length=3)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "code": "abc"},
+        {"id": 2, "code": "ab"},
+        {"id": 3, "code": None},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the too-short value fails; the null row passes:
+
+```text
++----+---+--------------------------------------------+----------+--------------------------+
+|code|id |_dq_errors                                  |_dq_passed|_dq_validation_ts         |
++----+---+--------------------------------------------+----------+--------------------------+
+|ab  |2  |[{StringMinLengthCheck, min-code, critical}]|false     |2026-01-01 00:00:00.000000|
++----+---+--------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Ensure codes, identifiers, or names meet a minimum meaningful length.
+- Detect truncated values from extraction or encoding issues.
+- Enforce minimum content on structured string fields.
+
+## Related checks
+
+- [String Max Length Check](string_max_length.md) — enforce an upper length bound.
+- [String Between Length Check](string_between_length.md) — enforce both length bounds.
+- [Regex Match Check](regex_match_check.md) — validate the value's format, not just its length.
 
 ---
 

--- a/docs/built_in_checks/checks/timestamp/timestamp_between_check.md
+++ b/docs/built_in_checks/checks/timestamp/timestamp_between_check.md
@@ -1,17 +1,26 @@
-# Timestamp Between
+---
+wide: true
+---
 
-**Check**: `timestamp-between-check`
+# Timestamp Between Check
 
-**Purpose**: Validates that values in timestamp columns fall within a defined range. A row fails if any selected column contains a timestamp before `min_value` or after `max_value`.
+**Check name**: `timestamp-between-check` · **Type**: row-level · **Config**: `TimestampBetweenCheckConfig`
 
-Use the `inclusive` parameter to control boundary behavior:
+Flags any record whose value in one of the configured timestamp columns falls
+outside a `[min, max]` range. Use it to constrain events to a valid time window.
 
-| Value                      | Behavior                                   |
-| -------------------------- | ------------------------------------------ |
-| `[false, false]` (default) | strictly between: `min < value < max`      |
-| `[true, false]`            | include lower bound: `min <= value < max`  |
-| `[false, true]`            | include upper bound: `min < value <= max`  |
-| `[true, true]`             | include both bounds: `min <= value <= max` |
+## Parameters
+
+| Parameter   | Type                | Required | Default          | Description                                                          |
+| ----------- | ------------------- | -------- | ---------------- | -------------------------------------------------------------------- |
+| `check_id`  | `str`               | yes      | —                | Unique identifier for this check within the `CheckSet`.              |
+| `columns`   | `list[str]`         | yes      | —                | Timestamp columns to compare against the range. YAML key: `columns`. |
+| `min_value` | `str`               | yes      | —                | Lower bound as an ISO timestamp. YAML key: `min-value`.              |
+| `max_value` | `str`               | yes      | —                | Upper bound as an ISO timestamp. YAML key: `max-value`.              |
+| `inclusive` | `tuple[bool, bool]` | no       | `(False, False)` | Inclusivity of the lower and upper bound respectively.               |
+| `severity`  | `Severity`          | no       | `CRITICAL`       | `CRITICAL` fails the row; `WARNING` only records it.                 |
+
+## Usage
 
 === "Python"
 
@@ -20,12 +29,12 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     TimestampBetweenCheckConfig(
-        check_id="event-time-within-range",
-        columns=["event_time"],
-        min_value="2020-01-01 00:00:00",
-        max_value="2023-12-31 23:59:59",
+        check_id="ts-2024",
+        columns=["ts"],
+        min_value="2024-01-01 00:00:00",
+        max_value="2024-12-31 23:59:59",
         inclusive=(True, True),
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -33,20 +42,105 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: timestamp-between-check
-      check-id: event-time-within-range
+      check-id: ts-2024
       columns:
-        - event_time
-      min-value: "2020-01-01 00:00:00"
-      max-value: "2023-12-31 23:59:59"
+        - ts
+      min-value: "2024-01-01 00:00:00"
+      max-value: "2024-12-31 23:59:59"
       inclusive: [true, true]
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure log entries or event timestamps fall within a defined processing or reporting window.
-- Validate that measurement or sensor data was collected within the expected observation period.
-- Reject future-dated or historically stale records before they reach downstream consumers.
+- **Bounds are ISO timestamp strings.** The column is cast to `timestamp` before
+  comparison.
+- **`inclusive` is a `(lower, upper)` pair and defaults to `(False, False)`** —
+  i.e. strictly between. Each bound is controlled independently (`(True, True)`
+  gives `min <= value <= max`).
+- **OR semantics across columns.** With multiple columns, a record fails if
+  _any_ of them lies outside the range.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`; with
+  the default severity, a failure sets `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist, the check
+  raises `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `ts` within calendar year 2024 (both bounds inclusive), both styles
+produce the same result.
+
+=== "Python"
+
+    ```python
+    import datetime
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import TimestampBetweenCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "ts": datetime.datetime(2024, 6, 1, 12, 0, 0)},
+        {"id": 2, "ts": datetime.datetime(2023, 1, 1, 0, 0, 0)},
+    ])
+
+    check_set = CheckSet().add_check(
+        TimestampBetweenCheckConfig(
+            check_id="ts-2024", columns=["ts"],
+            min_value="2024-01-01 00:00:00", max_value="2024-12-31 23:59:59", inclusive=(True, True),
+        )
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import datetime
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "ts": datetime.datetime(2024, 6, 1, 12, 0, 0)},
+        {"id": 2, "ts": datetime.datetime(2023, 1, 1, 0, 0, 0)},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+The out-of-range row fails; the in-range row passes:
+
+```text
++---+-------------------+--------------------------------------------+----------+--------------------------+
+|id |ts                 |_dq_errors                                  |_dq_passed|_dq_validation_ts         |
++---+-------------------+--------------------------------------------+----------+--------------------------+
+|2  |2023-01-01 00:00:00|[{TimestampBetweenCheck, ts-2024, critical}]|false     |2026-01-01 00:00:00.000000|
++---+-------------------+--------------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Constrain events to a valid time window.
+- Reject records outside a reporting or fiscal period.
+- Detect timestamp errors from upstream systems or migrations.
+
+## Related checks
+
+- [Timestamp Min Check](timestamp_min_check.md) — enforce only a lower bound.
+- [Timestamp Max Check](timestamp_max_check.md) — enforce only an upper bound.
 
 ---
 

--- a/docs/built_in_checks/checks/timestamp/timestamp_max_check.md
+++ b/docs/built_in_checks/checks/timestamp/timestamp_max_check.md
@@ -1,13 +1,26 @@
-# Timestamp Max
+---
+wide: true
+---
 
-**Check**: `timestamp-max-check`
+# Timestamp Max Check
 
-**Purpose**: Validates that values in timestamp columns do not exceed a defined maximum. A row fails if any selected column contains a timestamp after `max_value`.
+**Check name**: `timestamp-max-check` · **Type**: row-level · **Config**: `TimestampMaxCheckConfig`
 
-Use the `inclusive` parameter to control boundary behavior:
+Flags any record whose value in one of the configured timestamp columns is later
+than a maximum timestamp. Use it to reject future-dated events or timestamps
+beyond a valid window.
 
-- `inclusive: false` (default) — `value < max_value`
-- `inclusive: true` — `value <= max_value`
+## Parameters
+
+| Parameter   | Type        | Required | Default    | Description                                                              |
+| ----------- | ----------- | -------- | ---------- | ------------------------------------------------------------------------ |
+| `check_id`  | `str`       | yes      | —          | Unique identifier for this check within the `CheckSet`.                  |
+| `columns`   | `list[str]` | yes      | —          | Timestamp columns to compare against the threshold. YAML key: `columns`. |
+| `max_value` | `str`       | yes      | —          | Upper bound as an ISO timestamp. YAML key: `max-value`.                  |
+| `inclusive` | `bool`      | no       | `False`    | Whether `max_value` itself is allowed (see Behavior).                    |
+| `severity`  | `Severity`  | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                     |
+
+## Usage
 
 === "Python"
 
@@ -16,11 +29,11 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     TimestampMaxCheckConfig(
-        check_id="event-time-not-in-future",
-        columns=["event_time"],
-        max_value="2023-12-31 23:59:59",
+        check_id="max-ts",
+        columns=["ts"],
+        max_value="2024-12-31 23:59:59",
         inclusive=True,
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -28,19 +41,103 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: timestamp-max-check
-      check-id: event-time-not-in-future
+      check-id: max-ts
       columns:
-        - event_time
-      max-value: "2023-12-31 23:59:59"
+        - ts
+      max-value: "2024-12-31 23:59:59"
       inclusive: true
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure that event or log timestamps do not lie in the future.
-- Enforce a processing cutoff for pipelines that only consume data up to a specific point in time.
-- Detect future-dated records produced by system clock errors or incorrect timezone handling.
+- **`max_value` is an ISO timestamp string.** The column is cast to `timestamp`
+  before comparison.
+- **`inclusive` controls the boundary, and defaults to `False`.** With
+  `inclusive=True`, a value equal to `max_value` **passes** (`value <= max_value`).
+  With the default, the boundary instant itself **fails** (`value < max_value`).
+- **OR semantics across columns.** With multiple columns, a record fails if
+  _any_ of them is after the threshold.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`; with
+  the default severity, a failure sets `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist, the check
+  raises `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `ts <= 2024-12-31 23:59:59` (`inclusive=True`), both styles produce the
+same result.
+
+=== "Python"
+
+    ```python
+    import datetime
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import TimestampMaxCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "ts": datetime.datetime(2024, 6, 1, 12, 0, 0)},
+        {"id": 2, "ts": datetime.datetime(2025, 1, 1, 0, 0, 0)},
+    ])
+
+    check_set = CheckSet().add_check(
+        TimestampMaxCheckConfig(
+            check_id="max-ts", columns=["ts"], max_value="2024-12-31 23:59:59", inclusive=True
+        )
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import datetime
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "ts": datetime.datetime(2024, 6, 1, 12, 0, 0)},
+        {"id": 2, "ts": datetime.datetime(2025, 1, 1, 0, 0, 0)},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the too-late row fails:
+
+```text
++---+-------------------+---------------------------------------+----------+--------------------------+
+|id |ts                 |_dq_errors                             |_dq_passed|_dq_validation_ts         |
++---+-------------------+---------------------------------------+----------+--------------------------+
+|2  |2025-01-01 00:00:00|[{TimestampMaxCheck, max-ts, critical}]|false     |2026-01-01 00:00:00.000000|
++---+-------------------+---------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Reject future-dated events where only past timestamps are valid.
+- Enforce an upper bound aligned with a reporting or snapshot window.
+- Detect clock or timezone errors producing out-of-range timestamps.
+
+## Related checks
+
+- [Timestamp Min Check](timestamp_min_check.md) — enforce a lower bound.
+- [Timestamp Between Check](timestamp_between_check.md) — enforce both bounds at once.
 
 ---
 

--- a/docs/built_in_checks/checks/timestamp/timestamp_min_check.md
+++ b/docs/built_in_checks/checks/timestamp/timestamp_min_check.md
@@ -1,13 +1,25 @@
-# Timestamp Min
+---
+wide: true
+---
 
-**Check**: `timestamp-min-check`
+# Timestamp Min Check
 
-**Purpose**: Validates that values in timestamp columns are not earlier than a defined minimum. A row fails if any selected column contains a timestamp before `min_value`.
+**Check name**: `timestamp-min-check` · **Type**: row-level · **Config**: `TimestampMinCheckConfig`
 
-Use the `inclusive` parameter to control boundary behavior:
+Flags any record whose value in one of the configured timestamp columns is earlier
+than a minimum timestamp. Use it to reject events before a valid start instant.
 
-- `inclusive: false` (default) — `value > min_value`
-- `inclusive: true` — `value >= min_value`
+## Parameters
+
+| Parameter   | Type        | Required | Default    | Description                                                              |
+| ----------- | ----------- | -------- | ---------- | ------------------------------------------------------------------------ |
+| `check_id`  | `str`       | yes      | —          | Unique identifier for this check within the `CheckSet`.                  |
+| `columns`   | `list[str]` | yes      | —          | Timestamp columns to compare against the threshold. YAML key: `columns`. |
+| `min_value` | `str`       | yes      | —          | Lower bound as an ISO timestamp. YAML key: `min-value`.                  |
+| `inclusive` | `bool`      | no       | `False`    | Whether `min_value` itself is allowed (see Behavior).                    |
+| `severity`  | `Severity`  | no       | `CRITICAL` | `CRITICAL` fails the row; `WARNING` only records it.                     |
+
+## Usage
 
 === "Python"
 
@@ -16,11 +28,11 @@ Use the `inclusive` parameter to control boundary behavior:
     from sparkdq.core import Severity
 
     TimestampMinCheckConfig(
-        check_id="event-time-not-before-start",
-        columns=["event_time"],
-        min_value="2020-01-01 00:00:00",
+        check_id="min-ts",
+        columns=["ts"],
+        min_value="2024-01-01 00:00:00",
         inclusive=True,
-        severity=Severity.CRITICAL
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -28,19 +40,103 @@ Use the `inclusive` parameter to control boundary behavior:
 
     ```yaml
     - check: timestamp-min-check
-      check-id: event-time-not-before-start
+      check-id: min-ts
       columns:
-        - event_time
-      min-value: "2020-01-01 00:00:00"
+        - ts
+      min-value: "2024-01-01 00:00:00"
       inclusive: true
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure that event or log timestamps are not older than the defined operational start time.
-- Validate that data collection began after a system go-live or migration cutover point.
-- Reject historically stale records outside the defined processing window.
+- **`min_value` is an ISO timestamp string.** The column is cast to `timestamp`
+  before comparison.
+- **`inclusive` controls the boundary, and defaults to `False`.** With
+  `inclusive=True`, a value equal to `min_value` **passes** (`value >= min_value`).
+  With the default, the boundary instant itself **fails** (`value > min_value`).
+- **OR semantics across columns.** With multiple columns, a record fails if
+  _any_ of them is before the threshold.
+- **Failure is row-level.** Each failing row is annotated in `_dq_errors`; with
+  the default severity, a failure sets `_dq_passed = False`.
+- **Missing columns raise.** If a configured column does not exist, the check
+  raises `MissingColumnError` at validation time.
+
+## Example
+
+Requiring `ts >= 2024-01-01 00:00:00` (`inclusive=True`), both styles produce the
+same result.
+
+=== "Python"
+
+    ```python
+    import datetime
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import TimestampMinCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "ts": datetime.datetime(2024, 6, 1, 12, 0, 0)},
+        {"id": 2, "ts": datetime.datetime(2023, 1, 1, 0, 0, 0)},
+    ])
+
+    check_set = CheckSet().add_check(
+        TimestampMinCheckConfig(
+            check_id="min-ts", columns=["ts"], min_value="2024-01-01 00:00:00", inclusive=True
+        )
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+=== "YAML"
+
+    ```python
+    import datetime
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "ts": datetime.datetime(2024, 6, 1, 12, 0, 0)},
+        {"id": 2, "ts": datetime.datetime(2023, 1, 1, 0, 0, 0)},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+    result.fail_df().show(truncate=False)
+    ```
+
+Only the too-early row fails:
+
+```text
++---+-------------------+---------------------------------------+----------+--------------------------+
+|id |ts                 |_dq_errors                             |_dq_passed|_dq_validation_ts         |
++---+-------------------+---------------------------------------+----------+--------------------------+
+|2  |2023-01-01 00:00:00|[{TimestampMinCheck, min-ts, critical}]|false     |2026-01-01 00:00:00.000000|
++---+-------------------+---------------------------------------+----------+--------------------------+
+```
+
+## Typical use cases
+
+- Reject events recorded before a valid start instant.
+- Enforce a lower bound aligned with a system launch time.
+- Detect clock or timezone errors producing out-of-range timestamps.
+
+## Related checks
+
+- [Timestamp Max Check](timestamp_max_check.md) — enforce an upper bound.
+- [Timestamp Between Check](timestamp_between_check.md) — enforce both bounds at once.
 
 ---
 

--- a/docs/built_in_checks/checks/uniqueness/distinct_ratio_check.md
+++ b/docs/built_in_checks/checks/uniqueness/distinct_ratio_check.md
@@ -1,8 +1,24 @@
-# Distinct Ratio
+---
+wide: true
+---
 
-**Check**: `distinct-ratio-check`
+# Distinct Ratio Check
 
-**Purpose**: Validates that the ratio of distinct non-null values in a column meets or exceeds a defined threshold. The check fails if the actual distinct ratio falls below `min_ratio`.
+**Check name**: `distinct-ratio-check` · **Type**: aggregate · **Config**: `DistinctRatioCheckConfig`
+
+Validates that the share of **distinct** values in a column meets a minimum ratio.
+Use it to detect low-cardinality columns or excessive repetition.
+
+## Parameters
+
+| Parameter   | Type       | Required | Default    | Description                                                          |
+| ----------- | ---------- | -------- | ---------- | -------------------------------------------------------------------- |
+| `check_id`  | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.              |
+| `column`    | `str`      | yes      | —          | The column whose distinct ratio is measured.                         |
+| `min_ratio` | `float`    | yes      | —          | Minimum required distinct ratio, `0.0`–`1.0`. YAML key: `min-ratio`. |
+| `severity`  | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports.            |
+
+## Usage
 
 === "Python"
 
@@ -11,10 +27,10 @@
     from sparkdq.core import Severity
 
     DistinctRatioCheckConfig(
-        check_id="category-distinct-ratio",
-        column="category",
-        min_ratio=0.8,
-        severity=Severity.CRITICAL
+        check_id="email-distinct-ratio",
+        column="email",
+        min_ratio=0.9,
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -22,17 +38,98 @@
 
     ```yaml
     - check: distinct-ratio-check
-      check-id: category-distinct-ratio
-      column: category
-      min-ratio: 0.8
+      check-id: email-distinct-ratio
+      column: email
+      min-ratio: 0.9
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Detect columns with excessive repetition or insufficient value diversity.
-- Identify constant-filled, default-padded, or data-entry-error-prone fields.
-- Enforce minimum entropy requirements for features used in ML models or analytics pipelines.
+- **Distinct means "number of different values".** The ratio is
+  `distinct_count / row_count`. This differs from the
+  [Unique Ratio Check](unique_ratio_check.md), which counts only values appearing
+  exactly once.
+- **A critical failure fails the batch.** A failing `CRITICAL` aggregate marks
+  _every_ row `_dq_passed = False`. A `WARNING` failure is reported only.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict reports `distinct_count`, `row_count`, `distinct_ratio`, and
+  `min_expected_ratio`.
+
+## Example
+
+Requiring a 90% distinct ratio on a two-value column, the check fails.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import DistinctRatioCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": "a@example.com"},
+        {"id": 3, "email": "b@example.com"},
+        {"id": 4, "email": "b@example.com"},
+    ])
+
+    check_set = CheckSet().add_check(
+        DistinctRatioCheckConfig(check_id="email-distinct-ratio", column="email", min_ratio=0.9)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": "a@example.com"},
+        {"id": 3, "email": "b@example.com"},
+        {"id": 4, "email": "b@example.com"},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result reports the failure and the observed ratio:
+
+```text
+email-distinct-ratio False {'distinct_count': 2, 'row_count': 4, 'distinct_ratio': 0.5, 'min_expected_ratio': 0.9}
+```
+
+## Typical use cases
+
+- Detect low-cardinality columns that should carry more variety.
+- Catch stuck or defaulted values dominating a column.
+- Monitor cardinality health over time.
+
+## Related checks
+
+- [Unique Ratio Check](unique_ratio_check.md) — count values appearing exactly once.
+- [Unique Rows Check](unique_rows_check.md) — require full uniqueness (no duplicates).
 
 ---
 

--- a/docs/built_in_checks/checks/uniqueness/unique_ratio_check.md
+++ b/docs/built_in_checks/checks/uniqueness/unique_ratio_check.md
@@ -1,11 +1,25 @@
-# Unique Ratio
+---
+wide: true
+---
 
-**Check**: `unique-ratio-check`
+# Unique Ratio Check
 
-**Purpose**: Validates that the ratio of unique non-null values in a column meets or exceeds a defined threshold. The check fails if the proportion of unique values falls below `min_ratio`.
+**Check name**: `unique-ratio-check` · **Type**: aggregate · **Config**: `UniqueRatioCheckConfig`
 
-!!! note
-Null values are excluded from the uniqueness calculation. The total number of rows (including nulls) is used as the denominator.
+Validates that the share of **unique** (appearing exactly once) non-null values
+in a column meets a minimum ratio. Use it to bound the amount of duplication in a
+near-key column.
+
+## Parameters
+
+| Parameter   | Type       | Required | Default    | Description                                                        |
+| ----------- | ---------- | -------- | ---------- | ------------------------------------------------------------------ |
+| `check_id`  | `str`      | yes      | —          | Unique identifier for this check within the `CheckSet`.            |
+| `column`    | `str`      | yes      | —          | The column whose uniqueness ratio is measured.                     |
+| `min_ratio` | `float`    | yes      | —          | Minimum required unique ratio, `0.0`–`1.0`. YAML key: `min-ratio`. |
+| `severity`  | `Severity` | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports.          |
+
+## Usage
 
 === "Python"
 
@@ -14,10 +28,10 @@ Null values are excluded from the uniqueness calculation. The total number of ro
     from sparkdq.core import Severity
 
     UniqueRatioCheckConfig(
-        check_id="order-id-unique-ratio",
-        column="order_id",
-        min_ratio=0.95,
-        severity=Severity.CRITICAL
+        check_id="email-unique-ratio",
+        column="email",
+        min_ratio=0.9,
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -25,17 +39,99 @@ Null values are excluded from the uniqueness calculation. The total number of ro
 
     ```yaml
     - check: unique-ratio-check
-      check-id: order-id-unique-ratio
-      column: order_id
-      min-ratio: 0.95
+      check-id: email-unique-ratio
+      column: email
+      min-ratio: 0.9
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Ensure that columns expected to be mostly unique (e.g., IDs, hashes, transaction codes) behave as intended.
-- Detect high-cardinality violations where a small set of values is unexpectedly repeated at scale.
-- Support feature quality validation in ML preprocessing pipelines.
+- **Unique means "appears exactly once".** The ratio is
+  `unique_count / total_count`, where `unique_count` counts values occurring a
+  single time. This differs from the
+  [Distinct Ratio Check](distinct_ratio_check.md), which counts _distinct_ values.
+- **A critical failure fails the batch.** A failing `CRITICAL` aggregate marks
+  _every_ row `_dq_passed = False`. A `WARNING` failure is reported only.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict reports `total_count`, `unique_count`, `actual_ratio`, and
+  `min_required_ratio`.
+
+## Example
+
+Requiring a 90% unique ratio on a column where every value repeats, the check
+fails.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import UniqueRatioCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": "a@example.com"},
+        {"id": 3, "email": "b@example.com"},
+        {"id": 4, "email": "b@example.com"},
+    ])
+
+    check_set = CheckSet().add_check(
+        UniqueRatioCheckConfig(check_id="email-unique-ratio", column="email", min_ratio=0.9)
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": "a@example.com"},
+        {"id": 3, "email": "b@example.com"},
+        {"id": 4, "email": "b@example.com"},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result reports the failure and the observed ratio:
+
+```text
+email-unique-ratio False {'column': 'email', 'total_count': 4, 'unique_count': 2, 'actual_ratio': 0.5, 'min_required_ratio': 0.9}
+```
+
+## Typical use cases
+
+- Bound duplication in a near-key or identifier column.
+- Monitor the health of a column expected to be mostly unique.
+- Detect a spike in repeated values from upstream issues.
+
+## Related checks
+
+- [Unique Rows Check](unique_rows_check.md) — require full uniqueness (no duplicates).
+- [Distinct Ratio Check](distinct_ratio_check.md) — measure distinct values instead of singletons.
 
 ---
 

--- a/docs/built_in_checks/checks/uniqueness/unique_rows_check.md
+++ b/docs/built_in_checks/checks/uniqueness/unique_rows_check.md
@@ -1,11 +1,24 @@
-# Unique Rows
+---
+wide: true
+---
 
-**Check**: `unique-rows-check`
+# Unique Rows Check
 
-**Purpose**: Validates that all rows in the dataset are unique, either across all columns or a defined subset. The check fails on any duplicate row within the evaluated scope.
+**Check name**: `unique-rows-check` · **Type**: aggregate · **Config**: `UniqueRowsCheckConfig`
 
-!!! note
-If no `subset_columns` are provided, uniqueness is evaluated across all columns.
+Validates that the dataset contains no duplicate rows. Duplication can be checked
+across the full row or a subset of key columns. Use it to enforce primary-key or
+grain uniqueness.
+
+## Parameters
+
+| Parameter        | Type                | Required | Default    | Description                                                                        |
+| ---------------- | ------------------- | -------- | ---------- | ---------------------------------------------------------------------------------- |
+| `check_id`       | `str`               | yes      | —          | Unique identifier for this check within the `CheckSet`.                            |
+| `subset_columns` | `list[str] \| None` | no       | `None`     | Columns defining uniqueness; `None` uses the full row. YAML key: `subset-columns`. |
+| `severity`       | `Severity`          | no       | `CRITICAL` | `CRITICAL` fails the whole batch; `WARNING` only reports.                          |
+
+## Usage
 
 === "Python"
 
@@ -14,9 +27,9 @@ If no `subset_columns` are provided, uniqueness is evaluated across all columns.
     from sparkdq.core import Severity
 
     UniqueRowsCheckConfig(
-        check_id="no-duplicate-trips",
-        subset_columns=["trip_id", "pickup_time"],
-        severity=Severity.CRITICAL
+        check_id="unique-email",
+        subset_columns=["email"],
+        severity=Severity.CRITICAL,
     )
     ```
 
@@ -24,18 +37,95 @@ If no `subset_columns` are provided, uniqueness is evaluated across all columns.
 
     ```yaml
     - check: unique-rows-check
-      check-id: no-duplicate-trips
+      check-id: unique-email
       subset-columns:
-        - trip_id
-        - pickup_time
+        - email
       severity: critical
     ```
 
-## Typical Use Cases
+## Behavior
 
-- Enforce uniqueness on primary key–like columns such as `trip_id` or `user_id`.
-- Detect duplicate records introduced by faulty joins, reprocessing, or double ingestion.
-- Validate the correctness of deduplication logic before writing to transactional stores.
+- **Dataset-level verdict.** Fails if any duplicate exists across the chosen
+  columns (or the full row when `subset_columns` is omitted).
+- **A critical failure fails the batch.** A failing `CRITICAL` aggregate marks
+  _every_ row `_dq_passed = False`. A `WARNING` failure is reported only.
+- **Result and metrics.** Available via `result.aggregate_results`; the `metrics`
+  dict reports the number of `duplicate_row_groups` and the `checked_columns`.
+
+## Example
+
+Requiring unique `email` on a dataset with duplicates, the check fails.
+
+=== "Python"
+
+    ```python
+    from pyspark.sql import SparkSession
+    from sparkdq.checks import UniqueRowsCheckConfig
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": "a@example.com"},
+        {"id": 3, "email": "b@example.com"},
+        {"id": 4, "email": "b@example.com"},
+    ])
+
+    check_set = CheckSet().add_check(
+        UniqueRowsCheckConfig(check_id="unique-email", subset_columns=["email"])
+    )
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+=== "YAML"
+
+    ```python
+    import yaml
+    from pyspark.sql import SparkSession
+    from sparkdq.engine import BatchDQEngine
+    from sparkdq.management import CheckSet
+
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.createDataFrame([
+        {"id": 1, "email": "a@example.com"},
+        {"id": 2, "email": "a@example.com"},
+        {"id": 3, "email": "b@example.com"},
+        {"id": 4, "email": "b@example.com"},
+    ])
+
+    with open("checks.yml") as f:
+        config = yaml.safe_load(f)
+
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts(config)
+    result = BatchDQEngine(check_set).run_batch(df)
+
+    for r in result.aggregate_results:
+        print(r.check_id, r.passed, r.metrics)
+    ```
+
+The aggregate result reports the failure and how many duplicate groups exist:
+
+```text
+unique-email False {'duplicate_row_groups': 2, 'checked_columns': ['email']}
+```
+
+## Typical use cases
+
+- Enforce primary-key or business-key uniqueness.
+- Detect duplicate ingestion or fan-out from a bad join.
+- Validate the grain of a fact or dimension table.
+
+## Related checks
+
+- [Unique Ratio Check](unique_ratio_check.md) — tolerate some duplication via a ratio threshold.
+- [Distinct Ratio Check](distinct_ratio_check.md) — measure the share of distinct values.
 
 ---
 

--- a/docs/built_in_checks/row_level.md
+++ b/docs/built_in_checks/row_level.md
@@ -12,7 +12,7 @@ Row-level checks validate each record individually. If a row fails a check, it i
 | [Exactly One Not Null](checks/null/exactly_one_not_null_check.md)       | Exactly one of the specified columns is non-null per row.           |
 | [Is Contained In](checks/contained_in/is_contained_in_check.md)         | Column values are within a predefined set of allowed values.        |
 | [Is Not Contained In](checks/contained_in/is_not_contained_in_check.md) | Column values are not within a set of forbidden values.             |
-| [Not Null](checks/null/not_null_check.md)                               | Column contains at least one non-null value.                        |
+| [Not Null](checks/null/not_null_check.md)                               | Columns are expected to stay null; flags rows that contain a value. |
 | [Null Check](checks/null/null_check.md)                                 | Column contains no null values.                                     |
 | [Numeric Between](checks/numeric/numeric_between_check.md)              | Numeric values fall within a defined range.                         |
 | [Numeric Max](checks/numeric/numeric_max_check.md)                      | Numeric values do not exceed a defined maximum.                     |

--- a/docs/custom_checks/implementation.md
+++ b/docs/custom_checks/implementation.md
@@ -56,7 +56,8 @@ class PositiveValueCheckConfig(BaseRowCheckConfig):
 === "Python"
 
     ```python
-    check_set = CheckSet().add_checks_from_dicts([
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts([
         {"check": "positive-value", "check-id": "positive-salary", "column": "salary"}
     ])
     ```
@@ -113,7 +114,8 @@ class RowCountMinCheckConfig(BaseAggregateCheckConfig):
 === "Python"
 
     ```python
-    check_set = CheckSet().add_checks_from_dicts([
+    check_set = CheckSet()
+    check_set.add_checks_from_dicts([
         {"check": "custom-row-count-min", "check-id": "min-records", "min-count": 1000}
     ])
     ```

--- a/docs/custom_checks/implementation.md
+++ b/docs/custom_checks/implementation.md
@@ -32,7 +32,7 @@ Rows where the condition evaluates to `True` are marked as **failing**.
 from pyspark.sql import DataFrame
 from pyspark.sql import functions as F
 
-from sparkdq.core import BaseRowCheck, Severity
+from sparkdq.core import BaseRowCheck, BaseRowCheckConfig, Severity
 from sparkdq.plugin import register_check_config
 
 

--- a/docs/custom_checks/overview.md
+++ b/docs/custom_checks/overview.md
@@ -43,7 +43,8 @@ Once registered, the check is available declaratively by name. The factory resol
 ```python
 from sparkdq.management import CheckSet
 
-check_set = CheckSet().add_checks_from_dicts([
+check_set = CheckSet()
+check_set.add_checks_from_dicts([
     {"check": "positive-value", "check-id": "positive-salary", "column": "salary"}
 ])
 ```

--- a/docs/getting_started/applying_validation.md
+++ b/docs/getting_started/applying_validation.md
@@ -35,9 +35,9 @@ Use this when clean data should flow forward uninterrupted while invalid records
 are set aside for remediation, alerting, or backfill.
 
 !!! tip "Cache before deriving multiple views"
-Each of `pass_df()`, `fail_df()`, `warn_df()`, and `summary()` triggers a
-Spark action over the validated data. If you use more than one, cache the
-result once to avoid recomputing the plan:
+    Each of `pass_df()`, `fail_df()`, `warn_df()`, and `summary()` triggers a
+    Spark action over the validated data. If you use more than one, cache the
+    result once to avoid recomputing the plan:
 
     ```python
     result.df.cache()

--- a/docs/getting_started/applying_validation.md
+++ b/docs/getting_started/applying_validation.md
@@ -1,27 +1,60 @@
-# Integration Patterns
+# Acting on Results
 
-After running the validation engine, you need to decide what to do with the results. The right approach depends on how much trust your downstream systems require and how you want to handle bad data.
+Once `run_batch` returns a `result`, you decide what happens next. The right
+pattern depends on how much trust downstream systems require and how you want to
+handle bad data. Two common approaches — fail-fast and quarantine — each take
+only a few lines, and both build on the `result` from the
+[previous step](validation_dataframes.md).
 
-SparkDQ supports two common patterns: stopping the pipeline entirely when data quality is critical, or separating valid and invalid records so both can be handled independently. Both can be implemented with just a few lines of code.
+## Fail-fast
 
-## Fail-Fast
-
-Stop the pipeline immediately if any critical check fails. No data is written downstream.
+Stop the pipeline as soon as data quality drops, before anything is written
+downstream. `summary().all_passed` is `True` only when every row passed:
 
 ```python
 if not result.summary().all_passed:
-    raise RuntimeError("Critical checks failed — stopping pipeline.")
+    raise RuntimeError("Data quality checks failed — stopping pipeline.")
 ```
 
-Use this when your downstream consumers require complete trust in the data, or when you operate in regulated domains where partial data is worse than no data.
+Use this when downstream consumers require complete trust in the data, or in
+regulated domains where partial data is worse than no data. In the `orders`
+scenario this raises, because two of three rows failed a critical check.
 
 ## Quarantine
 
-Route valid and invalid records to separate destinations. Failing records are enriched with `_dq_errors`, `_dq_passed`, and `_dq_validation_ts` — giving you full context for debugging and monitoring.
+Route valid and invalid records to separate destinations, so clean data flows on
+while bad records are preserved for inspection. Failing rows keep their
+`_dq_errors` metadata, giving you the full reason for each rejection:
 
 ```python
-result.pass_df().write.format("delta").save("/trusted-zone")
-result.fail_df().write.format("delta").save("/quarantine-zone")
+result.pass_df().write.format("delta").save("/trusted/orders")
+result.fail_df().write.format("delta").save("/quarantine/orders")
 ```
 
-Use this when you want clean data to flow forward uninterrupted while preserving invalid records for inspection, remediation, or alerting.
+Use this when clean data should flow forward uninterrupted while invalid records
+are set aside for remediation, alerting, or backfill.
+
+!!! tip "Cache before deriving multiple views"
+Each of `pass_df()`, `fail_df()`, `warn_df()`, and `summary()` triggers a
+Spark action over the validated data. If you use more than one, cache the
+result once to avoid recomputing the plan:
+
+    ```python
+    result.df.cache()
+    ```
+
+## Warnings alongside either pattern
+
+Warnings never fail a row, so they compose with both patterns. Log them for
+monitoring while the pipeline continues:
+
+```python
+warn_count = result.warn_df().count()
+if warn_count:
+    logger.warning("%d record(s) passed with warnings", warn_count)
+```
+
+That completes the core workflow: **define** checks, **collect** them in a
+`CheckSet`, **run** the engine, and **act** on the result. From here, browse the
+[built-in checks](../built_in_checks/row_level.md) or learn to write your own in
+[Custom Checks](../custom_checks/overview.md).

--- a/docs/getting_started/defining_checks.md
+++ b/docs/getting_started/defining_checks.md
@@ -1,17 +1,27 @@
 # Defining Checks
 
-SparkDQ supports two types of checks: **row-level** checks that validate each record individually, and **aggregate** checks that evaluate the dataset as a whole. Both can be defined directly in Python or loaded declaratively from YAML or JSON.
+A check is defined through a typed **config class**. SparkDQ supports two kinds:
+**row-level** checks that validate each record individually, and **aggregate**
+checks that evaluate the dataset as a whole. Both can be written directly in
+Python or loaded declaratively from YAML or JSON.
 
-Every check accepts an optional `severity` parameter: `Severity.CRITICAL` (default) marks failing rows as invalid, `Severity.WARNING` records the violation but keeps the rows in `pass_df()`.
+Every check accepts an optional `severity`: `Severity.CRITICAL` (default) marks
+failing rows invalid, while `Severity.WARNING` records the violation but keeps
+the rows in `pass_df()`.
 
-## Python-native Configuration
+We will define the three rules from the [introduction](introduction.md) scenario:
+`customer_email` must not be null, `amount` must be positive, and the batch must
+contain at least 100 rows.
 
-For dynamic or code-driven use cases (e.g. notebooks, CI pipelines), you can define checks directly in Python using type-safe config classes. The `CheckSet` supports both the classic and the fluent API style.
+## Python-native
+
+For code-driven use (notebooks, CI pipelines), define checks with type-safe
+config classes. `CheckSet` supports both a fluent and a classic style.
 
 === "Fluent API (recommended)"
 
     ```python
-    from sparkdq.checks import NullCheckConfig, RowCountBetweenCheckConfig
+    from sparkdq.checks import NullCheckConfig, NumericMinCheckConfig, RowCountMinCheckConfig
     from sparkdq.core import Severity
     from sparkdq.management import CheckSet
 
@@ -19,15 +29,22 @@ For dynamic or code-driven use cases (e.g. notebooks, CI pipelines), you can def
         CheckSet()
         .add_check(
             NullCheckConfig(
-                check_id="my-null-check",
-                columns=["email"]
+                check_id="email-required",
+                columns=["customer_email"],
             )
         )
         .add_check(
-            RowCountBetweenCheckConfig(
-                check_id="my-count-check",
+            NumericMinCheckConfig(
+                check_id="amount-positive",
+                columns=["amount"],
+                min_value=0,
+            )
+        )
+        .add_check(
+            RowCountMinCheckConfig(
+                check_id="min-volume",
                 min_count=100,
-                max_count=5000
+                severity=Severity.WARNING,
             )
         )
     )
@@ -36,56 +53,76 @@ For dynamic or code-driven use cases (e.g. notebooks, CI pipelines), you can def
 === "Classic API"
 
     ```python
-    from sparkdq.checks import NullCheckConfig, RowCountBetweenCheckConfig
+    from sparkdq.checks import NullCheckConfig, NumericMinCheckConfig, RowCountMinCheckConfig
     from sparkdq.core import Severity
     from sparkdq.management import CheckSet
 
     check_set = CheckSet()
     check_set.add_check(
         NullCheckConfig(
-            check_id="my-null-check",
-            columns=["email"]
+            check_id="email-required",
+            columns=["customer_email"],
         )
     )
     check_set.add_check(
-        RowCountBetweenCheckConfig(
-            check_id="my-count-check",
+        NumericMinCheckConfig(
+            check_id="amount-positive",
+            columns=["amount"],
+            min_value=0,
+        )
+    )
+    check_set.add_check(
+        RowCountMinCheckConfig(
+            check_id="min-volume",
             min_count=100,
-            max_count=5000
+            severity=Severity.WARNING,
         )
     )
     ```
 
-## Declarative Configuration
+!!! tip "Choosing severity and check IDs"
+Use `CRITICAL` for rules that must hold for a record to be usable, and
+`WARNING` for signals you want to monitor without failing the batch. Give
+each check a stable, descriptive `check_id` — it appears verbatim in
+`_dq_errors`, so `email-required` reads better in a report than `check_1`.
 
-If you use a metadata-driven or config-as-code approach, SparkDQ also supports declarative check definitions via dictionaries — for example loaded from YAML or JSON files.
+## Declarative (YAML / JSON)
+
+For a metadata-driven or config-as-code approach, the same checks can be defined
+as dictionaries — for example loaded from a YAML file:
 
 ```yaml
-# dq_checks.yaml
+# checks.yml
 - check: null-check
-  check-id: my-null-check
+  check-id: email-required
   columns:
-    - email
-  severity: warning
+    - customer_email
 
-- check: row-count-between-check
-  check-id: my-count-check
+- check: numeric-min-check
+  check-id: amount-positive
+  columns:
+    - amount
+  min-value: 0
+
+- check: row-count-min-check
+  check-id: min-volume
   min-count: 100
-  max-count: 5000
+  severity: warning
 ```
 
-To load the configuration into SparkDQ, use the following code:
-
 !!! note
-SparkDQ does not install `pyyaml` or any other config parser. You are responsible for loading your config into a Python dictionary — SparkDQ only takes it from there.
+SparkDQ does not bundle `pyyaml` or any config parser. You load the config
+into a Python list of dicts; SparkDQ takes it from there.
 
 ```python
 import yaml
 from sparkdq.management import CheckSet
 
-with open("dq_checks.yaml") as f:
+with open("checks.yml") as f:
     config = yaml.safe_load(f)
 
 check_set = CheckSet()
 check_set.add_checks_from_dicts(config)
 ```
+
+Next: [validate a DataFrame](validation_dataframes.md) with this `CheckSet`.

--- a/docs/getting_started/defining_checks.md
+++ b/docs/getting_started/defining_checks.md
@@ -81,10 +81,10 @@ config classes. `CheckSet` supports both a fluent and a classic style.
     ```
 
 !!! tip "Choosing severity and check IDs"
-Use `CRITICAL` for rules that must hold for a record to be usable, and
-`WARNING` for signals you want to monitor without failing the batch. Give
-each check a stable, descriptive `check_id` — it appears verbatim in
-`_dq_errors`, so `email-required` reads better in a report than `check_1`.
+    Use `CRITICAL` for rules that must hold for a record to be usable, and
+    `WARNING` for signals you want to monitor without failing the batch. Give
+    each check a stable, descriptive `check_id` — it appears verbatim in
+    `_dq_errors`, so `email-required` reads better in a report than `check_1`.
 
 ## Declarative (YAML / JSON)
 
@@ -111,8 +111,8 @@ as dictionaries — for example loaded from a YAML file:
 ```
 
 !!! note
-SparkDQ does not bundle `pyyaml` or any config parser. You load the config
-into a Python list of dicts; SparkDQ takes it from there.
+    SparkDQ does not bundle `pyyaml` or any config parser. You load the config
+    into a Python list of dicts; SparkDQ takes it from there.
 
 ```python
 import yaml

--- a/docs/getting_started/introduction.md
+++ b/docs/getting_started/introduction.md
@@ -12,32 +12,40 @@ It is honest about where it stops: if you need automated data profiling, statist
 
 ## How it fits into your pipeline
 
-It is built for data engineers who work with PySpark and want a lightweight, non-invasive way to enforce data quality. There is no extra infrastructure, no external services, and no wrappers around your existing code. SparkDQ runs alongside your pipeline, validates your data in a single pass, and returns a structured result you can act on — whether that means stopping the pipeline, routing bad records to a quarantine zone, or simply logging what went wrong.
+SparkDQ is built for data engineers who work with PySpark and want a lightweight, non-invasive way to enforce data quality. There is no extra infrastructure, no external services, and no wrappers around your existing code. It runs alongside your pipeline, validates a DataFrame in a single pass, and returns a structured result you can act on — stop the pipeline, route bad records to a quarantine zone, or simply log what went wrong.
 
-To do that, it relies on a few components that build on each other.
+## Core concepts
 
-## Core Concepts
+Four building blocks compose into one flow:
 
-You start by defining a **CheckConfig** — a single validation rule, like "this column must not be null" or "the row count must be between 1,000 and 10,000". Each rule has its own config class with typed, validated parameters.
+```mermaid
+flowchart LR
+    A["<b>CheckConfig</b><br/>one validation rule"] --> B["<b>CheckSet</b><br/>collects the rules"] --> C["<b>BatchDQEngine</b><br/>runs them in one pass"] --> D["<b>ValidationResult</b><br/>pass / fail / warn / summary"]
+```
 
-Multiple configs are collected in a **CheckSet**, which acts as the single source of truth for everything you want to validate in one run.
+- **CheckConfig** — a single validation rule, such as "this column must not be null" or "the row count must be at least 1,000". Each rule has its own typed, validated config class.
+- **CheckSet** — the collection of configs and the single source of truth for one validation run.
+- **BatchDQEngine** — takes the CheckSet and a Spark DataFrame, applies every rule in a single pass, and produces the result.
+- **ValidationResult** — a structured object with filtered views of passed, failed, and warning-level records, plus summary statistics like pass rate.
 
-The **ValidationEngine** (e.g. `BatchDQEngine`) takes the CheckSet and a Spark DataFrame, applies all rules, and returns a **ValidationResult** — a structured object that gives you filtered views of passed, failed, and warning-level records, plus summary statistics like pass rate and timestamps.
+## A scenario to follow
 
-## Example
+The rest of this guide validates one small `orders` dataset end to end, enforcing three rules:
+
+| Rule                              | Check type | Severity   |
+| --------------------------------- | ---------- | ---------- |
+| `customer_email` must not be null | row-level  | `CRITICAL` |
+| `amount` must be greater than 0   | row-level  | `CRITICAL` |
+| at least 100 rows per batch       | aggregate  | `WARNING`  |
+
+The dataset contains one violation of each rule, so every result view has something to show:
 
 ```python
-from sparkdq.checks import NullCheckConfig
-from sparkdq.engine import BatchDQEngine
-from sparkdq.management import CheckSet
-
-check_set = CheckSet()
-check_set.add_check(NullCheckConfig(check_id="no-nulls-in-email", columns=["email"]))
-
-df = spark.read.parquet("/path/to/data")
-result = BatchDQEngine(check_set).run_batch(df)
-
-result.pass_df().show()
-result.fail_df().show()
-print(result.summary())
+df = spark.createDataFrame([
+    {"order_id": 1, "customer_email": "alice@example.com", "amount": 42.0},
+    {"order_id": 2, "customer_email": None,                "amount": 19.5},
+    {"order_id": 3, "customer_email": "carol@example.com", "amount": -5.0},
+])
 ```
+
+Next: [define these checks](defining_checks.md).

--- a/docs/getting_started/introduction.md
+++ b/docs/getting_started/introduction.md
@@ -2,7 +2,17 @@
 
 SparkDQ follows a simple idea: you describe what valid data looks like, and the framework checks it for you — directly inside your Spark pipeline.
 
-It is designed for data engineers who work with PySpark and need a lightweight, non-invasive way to enforce data quality. There is no extra infrastructure, no external services, and no wrappers around your existing code. SparkDQ runs alongside your pipeline, validates your data in a single pass, and gives you a structured result you can act on — whether that means stopping the pipeline, routing bad records to a quarantine zone, or simply logging what went wrong.
+## Deliberately small
+
+SparkDQ's defining trait is what it leaves out. It is intentionally small in scope and low in complexity: a focused set of row- and aggregate-level checks, a declarative configuration layer, and a single-pass engine — and little else. There is no metadata store, no orchestration layer, no profiling engine, and no data-docs pipeline to operate. You can read and understand the whole framework in an afternoon.
+
+That smaller surface is a design choice, not a limitation to apologize for. It means fewer moving parts to learn, fewer ways to misconfigure, and a codebase that stays easy to extend and maintain. For the large majority of pipelines — where the job is to enforce a known set of rules and route good and bad records accordingly — this is exactly enough, and the reduced complexity is a feature in itself.
+
+It is honest about where it stops: if you need automated data profiling, statistical anomaly detection, or a full data-quality platform with its own UI and storage, a heavier tool is the better fit. SparkDQ trades that breadth for clarity.
+
+## How it fits into your pipeline
+
+It is built for data engineers who work with PySpark and want a lightweight, non-invasive way to enforce data quality. There is no extra infrastructure, no external services, and no wrappers around your existing code. SparkDQ runs alongside your pipeline, validates your data in a single pass, and returns a structured result you can act on — whether that means stopping the pipeline, routing bad records to a quarantine zone, or simply logging what went wrong.
 
 To do that, it relies on a few components that build on each other.
 

--- a/docs/getting_started/validation_dataframes.md
+++ b/docs/getting_started/validation_dataframes.md
@@ -28,12 +28,16 @@ When `run_batch()` is called, the engine:
 
 ## Working with the Result
 
-| Method      | Description                                                         |
-| ----------- | ------------------------------------------------------------------- |
-| `pass_df()` | Records that passed all critical checks                             |
-| `fail_df()` | Records that failed at least one critical check                     |
-| `warn_df()` | Passing records that triggered one or more warning-level violations |
-| `summary()` | Structured summary with record counts, pass rate, and timestamp     |
+| Method      | Description                                                           |
+| ----------- | --------------------------------------------------------------------- |
+| `pass_df()` | Records that passed every failure-level check (`CRITICAL` by default) |
+| `fail_df()` | Records that failed at least one failure-level check                  |
+| `warn_df()` | Passing records that triggered one or more warning-level violations   |
+| `summary()` | Structured summary with record counts, pass rate, and timestamp       |
+
+By default only `CRITICAL` checks cause a row to fail; `WARNING` checks are
+recorded without failing the row. You can change which severities count as
+failures via the engine's `fail_levels` parameter.
 
 ## Result Columns
 
@@ -41,6 +45,6 @@ SparkDQ automatically adds the following columns to your DataFrame:
 
 | Column              | Description                                                            |
 | ------------------- | ---------------------------------------------------------------------- |
-| `_dq_passed`        | Boolean flag — `true` if the row passed all critical checks            |
+| `_dq_passed`        | Boolean flag — `true` if the row passed every failure-level check      |
 | `_dq_errors`        | Array of structured errors per failed check (check-id, name, severity) |
 | `_dq_validation_ts` | Timestamp of the validation run                                        |

--- a/docs/getting_started/validation_dataframes.md
+++ b/docs/getting_started/validation_dataframes.md
@@ -1,50 +1,111 @@
 # Validating DataFrames
 
-Once your checks are defined and grouped into a `CheckSet`, pass them to the `BatchDQEngine` together with your Spark DataFrame. The engine evaluates all rules in a single pass and returns a structured `BatchValidationResult`.
+Take the `check_set` from the [previous step](defining_checks.md) and the
+`orders` DataFrame from the [introduction](introduction.md), and pass both to a
+`BatchDQEngine`. The engine evaluates every rule in a single pass and returns a
+`BatchValidationResult`:
 
 ```python
-from sparkdq.checks import NullCheckConfig
 from sparkdq.engine import BatchDQEngine
-from sparkdq.management import CheckSet
-
-check_set = CheckSet()
-check_set.add_check(NullCheckConfig(check_id="my-null-check", columns=["email"]))
 
 result = BatchDQEngine(check_set).run_batch(df)
+```
 
-result.pass_df().show()
-result.fail_df().select("_dq_errors").show(truncate=False)
+## What the engine does
+
+In a single pass, the engine:
+
+- applies each row-level check and flags failing rows individually,
+- evaluates each aggregate check against the full DataFrame,
+- annotates every row with `_dq_passed` and `_dq_errors`,
+- returns a `BatchValidationResult` ready to be queried or routed.
+
+## Result views
+
+`BatchValidationResult` exposes filtered views over the annotated data:
+
+| View        | Returns                                                                              |
+| ----------- | ------------------------------------------------------------------------------------ |
+| `pass_df()` | Rows that passed every failure-level check (`CRITICAL` by default), original schema. |
+| `fail_df()` | Rows that failed at least one failure-level check, plus error metadata.              |
+| `warn_df()` | Passing rows that carry at least one `WARNING`-level violation.                      |
+| `summary()` | Counts, pass rate, and timestamp for the run.                                        |
+
+By default only `CRITICAL` checks cause a row to fail; `WARNING` checks are
+recorded without failing it. You can change which severities count as failures
+via the engine's `fail_levels` parameter.
+
+## Reading the result
+
+`pass_df()` returns only the clean order, restored to its original schema:
+
+```python
+result.pass_df().show(truncate=False)
+```
+
+```text
++------+-----------------+--------+
+|amount|customer_email   |order_id|
++------+-----------------+--------+
+|42.0  |alice@example.com|1       |
++------+-----------------+--------+
+```
+
+`fail_df()` returns the rows that failed a critical check, with `_dq_errors`
+listing every violation. Note the `WARNING`-level `min-volume` check appears here
+too, alongside the critical one that failed each row:
+
+```python
+result.fail_df().select("order_id", "_dq_errors", "_dq_passed").show(truncate=False)
+```
+
+```text
++--------+---------------------------------------------------------------------------------------+----------+
+|order_id|_dq_errors                                                                             |_dq_passed|
++--------+---------------------------------------------------------------------------------------+----------+
+|2       |[{NullCheck, email-required, critical}, {RowCountMinCheck, min-volume, warning}]       |false     |
+|3       |[{NumericMinCheck, amount-positive, critical}, {RowCountMinCheck, min-volume, warning}]|false     |
++--------+---------------------------------------------------------------------------------------+----------+
+```
+
+`warn_df()` surfaces rows that _passed_ but still carry a warning — here the valid
+order, flagged only by the batch-level `min-volume` check:
+
+```python
+result.warn_df().select("order_id", "_dq_errors").show(truncate=False)
+```
+
+```text
++--------+-----------------------------------------+
+|order_id|_dq_errors                               |
++--------+-----------------------------------------+
+|1       |[{RowCountMinCheck, min-volume, warning}]|
++--------+-----------------------------------------+
+```
+
+`summary()` gives run-level statistics:
+
+```python
 print(result.summary())
 ```
 
-## What Happens Under the Hood
+```text
+Validation Summary (2026-01-01 00:00:00)
+Total records:   3
+Passed records:  1
+Failed records:  2
+Warnings:        1
+Pass rate:       33.00%
+```
 
-When `run_batch()` is called, the engine:
+## Metadata columns
 
-- evaluates all row-level checks and marks failing rows individually
-- evaluates all aggregate checks against the full DataFrame
-- annotates every row with `_dq_passed`, `_dq_errors`, and `_dq_validation_ts`
-- returns a result object ready to be queried or routed
+The engine adds these columns to the DataFrame:
 
-## Working with the Result
+| Column              | Description                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| `_dq_passed`        | `true` if the row passed every failure-level check.                                           |
+| `_dq_errors`        | Array of `{check, check-id, severity}` structs for each violation (row- and aggregate-level). |
+| `_dq_validation_ts` | Timestamp of the run (added by `fail_df()` / `warn_df()`).                                    |
 
-| Method      | Description                                                           |
-| ----------- | --------------------------------------------------------------------- |
-| `pass_df()` | Records that passed every failure-level check (`CRITICAL` by default) |
-| `fail_df()` | Records that failed at least one failure-level check                  |
-| `warn_df()` | Passing records that triggered one or more warning-level violations   |
-| `summary()` | Structured summary with record counts, pass rate, and timestamp       |
-
-By default only `CRITICAL` checks cause a row to fail; `WARNING` checks are
-recorded without failing the row. You can change which severities count as
-failures via the engine's `fail_levels` parameter.
-
-## Result Columns
-
-SparkDQ automatically adds the following columns to your DataFrame:
-
-| Column              | Description                                                            |
-| ------------------- | ---------------------------------------------------------------------- |
-| `_dq_passed`        | Boolean flag — `true` if the row passed every failure-level check      |
-| `_dq_errors`        | Array of structured errors per failed check (check-id, name, severity) |
-| `_dq_validation_ts` | Timestamp of the validation run                                        |
+Next: [act on the result](applying_validation.md) in your pipeline.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,11 @@ hide:
 
 # SparkDQ — Data Quality Validation for Apache Spark
 
-**SparkDQ** is a lightweight data quality framework built natively for PySpark — no JVM bridge like [PyDeequ](https://github.com/awslabs/python-deequ), no complexity overhead like [Great Expectations](https://github.com/great-expectations/great_expectations), and no platform lock-in like [Databricks dqx](https://github.com/databrickslabs/dqx). Define checks declaratively via YAML/JSON or through a type-safe Python API, validate at row and aggregate level in a single pass, and extend the framework via a plugin system without touching the core.
+**SparkDQ** is a lightweight data quality framework built natively for PySpark. You describe what valid data looks like — declaratively via YAML/JSON or through a type-safe Python API — and it validates your DataFrame at row and aggregate level in a single pass, returning a structured result you can act on.
+
+Its defining trait is what it leaves out. SparkDQ is intentionally small in scope and low in complexity — a focused set of checks, a declarative config layer, and a single-pass engine, with no metadata store, orchestration layer, or profiling engine to operate. That is a deliberate design choice: fewer moving parts to learn, fewer ways to misconfigure, and a codebase you can understand in an afternoon. For the large majority of pipelines — enforcing a known set of rules and routing good and bad records accordingly — this is exactly enough. If you need automated profiling or a full data-quality platform with its own UI and storage, a heavier tool is the better fit; SparkDQ trades that breadth for clarity.
+
+That focus is what sets it apart from the alternatives: no JVM bridge like [PyDeequ](https://github.com/awslabs/python-deequ), no complexity overhead like [Great Expectations](https://github.com/great-expectations/great_expectations), and no platform lock-in like [Databricks dqx](https://github.com/databrickslabs/dqx). And when the built-in checks are not enough, you extend the framework via a plugin system without touching the core.
 
 ## Installation
 
@@ -32,6 +36,8 @@ The framework supports Python 3.11+ and is fully tested with PySpark 3.5.x.
 
 === "Declarative"
 
+    Checks are plain dictionaries, so they can be loaded from anywhere — YAML or JSON files, a database, or an API:
+
     ```python
     from pyspark.sql import SparkSession
     from sparkdq.engine import BatchDQEngine
@@ -54,17 +60,11 @@ The framework supports Python 3.11+ and is fully tested with PySpark 3.5.x.
 
     result = BatchDQEngine(check_set).run_batch(df)
     print(result.summary())
-    # Validation Summary (2024-01-01 00:00:00)
-    # Total records:   3
-    # Passed records:  2
-    # Failed records:  1
-    # Warnings:        0
-    # Pass rate:       67.00%
     ```
 
 === "Python-native"
 
-    Full type safety and IDE autocompletion:
+    Typed config classes give you full type safety, IDE autocompletion, and static analysis support:
 
     ```python
     from pyspark.sql import SparkSession
@@ -90,18 +90,24 @@ The framework supports Python 3.11+ and is fully tested with PySpark 3.5.x.
 
     result = BatchDQEngine(check_set).run_batch(df)
     print(result.summary())
-    # Validation Summary (2024-01-01 00:00:00)
-    # Total records:   3
-    # Passed records:  2
-    # Failed records:  1
-    # Warnings:        0
-    # Pass rate:       67.00%
     ```
 
-SparkDQ ships with 30+ built-in checks across null validation, numeric ranges, string patterns, date boundaries, schema enforcement, uniqueness, and referential integrity.
+Either way, `run_batch` produces the following summary:
+
+```text
+Validation Summary (2024-01-01 00:00:00)
+Total records:   3
+Passed records:  2
+Failed records:  1
+Warnings:        0
+Pass rate:       67.00%
+```
+
+SparkDQ ships with a library of over 30 built-in checks, spanning null and completeness validation, numeric and date range constraints, string pattern matching, schema enforcement, uniqueness, and referential integrity.
 
 ## Why SparkDQ?
 
+- **Small on purpose** — A focused scope and low complexity: quick to learn, hard to misconfigure, easy to maintain — and enough for most pipelines
 - **Extensible by design** — Add custom checks via a simple plugin system, no changes to the core required
 - **Declarative or Pythonic** — YAML/JSON configs or type-safe Python, your choice
 - **Severity-aware** — Distinguish between hard failures (`CRITICAL`) and soft constraints (`WARNING`)

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ The framework supports Python 3.11+ and is fully tested with PySpark 3.5.x.
 Either way, `run_batch` produces the following summary:
 
 ```text
-Validation Summary (2024-01-01 00:00:00)
+Validation Summary (2026-01-01 00:00:00)
 Total records:   3
 Passed records:  2
 Failed records:  1

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %} {# Opt-in wider content grid for individual pages. A
+page enables it by setting `wide: true` in its front matter. The rule is
+injected only on those pages, so the default width is untouched everywhere else.
+#} {% block extrahead %} {{ super() }} {% if page and page.meta and
+page.meta.wide %}
+<style>
+  @media screen and (min-width: 76.25em) {
+    .md-grid {
+      max-width: 76rem;
+    }
+  }
+</style>
+{% endif %} {% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ extra:
     - icon: fontawesome/brands/python
       link: https://pypi.org/project/sparkdq/
 
-copyright: Copyright &copy; 2025 Marcel Kennert-Diaz
+copyright: Copyright &copy; 2026 Marcel Kennert-Diaz
 
 nav:
   - Introduction: index.md
@@ -98,6 +98,9 @@ nav:
       - Custom Checks:
           - Overview: custom_checks/overview.md
           - Implementation: custom_checks/implementation.md
+  - Built-In Checks:
+      - Row-Level Checks: built_in_checks/row_level.md
+      - Aggregate Checks: built_in_checks/aggregate.md
   - Architecture:
       - Overview: architecture/overview.md
       - Core Abstractions: architecture/core_abstractions.md
@@ -110,9 +113,6 @@ nav:
           - Row vs. Aggregate: architecture/decisions/row_vs_aggregate.md
           - Observable Aggregation: architecture/decisions/observable_aggregation.md
           - DataFrame Annotations: architecture/decisions/dataframe_annotations.md
-  - Built-In Checks:
-      - Row-Level Checks: built_in_checks/row_level.md
-      - Aggregate Checks: built_in_checks/aggregate.md
   - API Reference:
       - Overview: api/index.md
       - sparkdq.checks: api/checks.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,11 @@ plugins:
 markdown_extensions:
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
@@ -90,6 +94,18 @@ nav:
       - Custom Checks:
           - Overview: custom_checks/overview.md
           - Implementation: custom_checks/implementation.md
+  - Architecture:
+      - Overview: architecture/overview.md
+      - Core Abstractions: architecture/core_abstractions.md
+      - Execution Flow: architecture/execution_flow.md
+      - Output Model: architecture/output_model.md
+      - Design Decisions:
+          - Overview: architecture/design_decisions.md
+          - Declarative Configuration: architecture/decisions/declarative_config.md
+          - Plugin System: architecture/decisions/plugin_system.md
+          - Row vs. Aggregate: architecture/decisions/row_vs_aggregate.md
+          - Observable Aggregation: architecture/decisions/observable_aggregation.md
+          - DataFrame Annotations: architecture/decisions/dataframe_annotations.md
   - Built-In Checks:
       - Row-Level Checks: built_in_checks/row_level.md
       - Aggregate Checks: built_in_checks/aggregate.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,8 +5,12 @@ repo_url: https://github.com/sparkdq-community/sparkdq
 repo_name: sparkdq-community/sparkdq
 edit_uri: edit/main/docs/
 
+exclude_docs: |
+  overrides/
+
 theme:
   name: material
+  custom_dir: docs/overrides
   logo: assets/logo.svg
   favicon: assets/logo.svg
   palette:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ test = [
     "pandas>=2.0.0",
     "pytest-mock>=3.14.0",
     "pyspark>=3.5.0,<4.0.0",    # Required for testing
+    # PySpark 3.5.x imports the stdlib `distutils`, removed in Python 3.12+.
+    # setuptools provides the compatibility shim so tests run on 3.12/3.13.
+    "setuptools>=69.0.0; python_version >= '3.12'",
 ]
 docs = [
     "mkdocs>=1.6.0,<2.0.0",

--- a/sparkdq/checks/aggregate/integrity_checks/foreign_key_check.py
+++ b/sparkdq/checks/aggregate/integrity_checks/foreign_key_check.py
@@ -79,7 +79,13 @@ class ForeignKeyCheckConfig(BaseAggregateCheckConfig):
     check_class = ForeignKeyCheck
 
     column: str = Field(..., description="The column in the source DataFrame to validate")
-    reference_dataset: str = Field(..., description="The name of the reference dataset to compare against")
+    reference_dataset: str = Field(
+        ...,
+        description="The name of the reference dataset to compare against",
+        alias="reference-dataset",
+    )
     reference_column: str = Field(
-        ..., description="The column in the reference dataset that contains valid values"
+        ...,
+        description="The column in the reference dataset that contains valid values",
+        alias="reference-column",
     )

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.15'",
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.14.*'",
     "python_full_version >= '3.12' and python_full_version < '3.14'",
     "python_full_version < '3.12'",
@@ -19,15 +21,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.13.0"
+version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
 ]
 
 [[package]]
@@ -146,27 +148,27 @@ wheels = [
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.14.3"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
 ]
 
 [[package]]
 name = "bleach"
-version = "6.3.0"
+version = "6.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
 ]
 
 [package.optional-dependencies]
@@ -176,11 +178,11 @@ css = [
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -353,14 +355,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -383,101 +385,86 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.14.1"
+version = "7.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/8b/adeb62ea8951f13c4c7fef2e7a85e1a06b499c8d8237ea589d496029e53f/coverage-7.15.0.tar.gz", hash = "sha256:9ac3fe7a1435986463eaa8ee253ae2f2a268709ba4ae5c7dd1f52a05391ad78f", size = 925362, upload-time = "2026-07-02T13:10:50.535Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/d7/477ad149490e6cb849f28abea1dabb9c823cea72e7500c81b4240ce619c0/coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f", size = 219848, upload-time = "2026-05-26T20:38:38.715Z" },
-    { url = "https://files.pythonhosted.org/packages/91/82/a5eb47257c50601bb7b9a9d2857c67b7a3a85ad74180eb2c98bb1fbe0ce5/coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4", size = 220354, upload-time = "2026-05-26T20:38:40.232Z" },
-    { url = "https://files.pythonhosted.org/packages/43/8b/78419b5391a5cb706b6544390507e469d83ffc9a8248b02c4011aceb9365/coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1", size = 250771, upload-time = "2026-05-26T20:38:41.782Z" },
-    { url = "https://files.pythonhosted.org/packages/77/63/e77aaacd491182210d639636b7a8bba23ffffa9b82aa3762da9431855fa9/coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f", size = 252683, upload-time = "2026-05-26T20:38:43.305Z" },
-    { url = "https://files.pythonhosted.org/packages/65/1c/a022e3cfbec2ac241640003cb3a817e161d9c7f5aa9b49173756cdc03204/coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129", size = 254791, upload-time = "2026-05-26T20:38:45.361Z" },
-    { url = "https://files.pythonhosted.org/packages/61/d6/967e408aca4c1ceb88cb0cc677169110ae7f5995fb5eaf5fb1f5a1bb8f5d/coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860", size = 256748, upload-time = "2026-05-26T20:38:46.91Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/be/869188f7fe28638078ec479331ace6dc5f7b40b7153eb616f47ab79404d8/coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c", size = 250907, upload-time = "2026-05-26T20:38:48.493Z" },
-    { url = "https://files.pythonhosted.org/packages/07/aa/adb7d3b4278d690e68703abcd76ab1b948242e3668d921711551b78f9ddb/coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7", size = 252483, upload-time = "2026-05-26T20:38:50.074Z" },
-    { url = "https://files.pythonhosted.org/packages/43/61/331c74103c62dcb0c4b9b3a0de9a61aca016208b0a90f109592a9f9ecc28/coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec", size = 250545, upload-time = "2026-05-26T20:38:51.613Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b6/c5dae3c104d89be04828f61810e6b3473825482e4c288cc4ed04553e08ae/coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef", size = 254310, upload-time = "2026-05-26T20:38:53.503Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/a1/2b9d5863e3b83c01ad8199e3c597802fbb3a9dc90b058885804c20296d31/coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df", size = 250266, upload-time = "2026-05-26T20:38:55.414Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/5e/0e511fbdb269359be26fe678a1c3fa1f2aa2a01573cc3f54268c8d6d4797/coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9", size = 251174, upload-time = "2026-05-26T20:38:57.141Z" },
-    { url = "https://files.pythonhosted.org/packages/85/10/e55307b622b3dd9671cb321824502dc10f93e72f2802b9946159a8edadeb/coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548", size = 222354, upload-time = "2026-05-26T20:38:58.727Z" },
-    { url = "https://files.pythonhosted.org/packages/71/cf/107421693cfb71e4f1ca5bf70443f64d4161878068d07a3e51c7ad21d17b/coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e", size = 223290, upload-time = "2026-05-26T20:39:00.413Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/1d/3e3644585eb29e9dafefb19555078529a4d7cce12bd21929664eea989277/coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3", size = 221953, upload-time = "2026-05-26T20:39:02.159Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
-    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
-    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
-    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
-    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
-    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
-    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
-    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
-    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
-    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
-    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
-    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
-    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
-    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
-    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
-    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
-    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
-    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
-    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
-    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
-    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
-    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
-    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/23/82e910835ef4b8391047025e1d53aa48d66029f444eb8b25373c849bf503/coverage-7.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:003fff99412ea848c0aaebcc78ed2b6ce7d8a1227ed17e68470672770b78a02a", size = 220662, upload-time = "2026-07-02T13:08:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/0d/c7b213dde2f1579de5231062b386d8413f79c11667eb58c39319b25991da/coverage-7.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5cbd804bf2784ce7b45114516050f346ecd50f960c4bb630a7ee9e1d78fa2118", size = 221168, upload-time = "2026-07-02T13:08:40.471Z" },
+    { url = "https://files.pythonhosted.org/packages/33/77/d000aeedfac085088337b3c7becdad328474b1f8a9e4c9368a0c99605d68/coverage-7.15.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8773e15c23305b58882a4611fb9b2755977eae0dc2e515366a1b6c98866cc4c2", size = 251587, upload-time = "2026-07-02T13:08:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/e0/86787c56b9df17afd370d5e293515dd4d9a107a561d13054873eefad8ecc/coverage-7.15.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f50e40081494c1dc4239ebb202014cbcc3306ea96fb6302a34c8cc0967fc5ae8", size = 253497, upload-time = "2026-07-02T13:08:43.387Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/02/181bc917359299c07dead6270f94e411151c8b60cec905c33499da69afe6/coverage-7.15.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daf96f37f5fc3a7b6c6da862eb4aee61c426bd63da236ed4a73ef0e503b4bca5", size = 255607, upload-time = "2026-07-02T13:08:44.897Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/35/ca5e7427699913da6788c4f910e73ab16c5f4b59ec5d3a999dce2a45112f/coverage-7.15.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:51aa20f6ae2788fd197747766edf4cd8234fd9423309b934257fa6b21a592723", size = 257563, upload-time = "2026-07-02T13:08:46.334Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/4d/b8220bacc2fc3c4e9078e27c32e99fb411479a4718a72bdd00036a9891c8/coverage-7.15.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03d1f922757662eb7af586e77834792274cff776bc7b1d1a0b66a49ea9d84735", size = 251726, upload-time = "2026-07-02T13:08:47.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e4/2e145da1991d72189b9c3cf7eca05c716ee7080d099aaea6757cfc7df008/coverage-7.15.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a6d6acc9a7666245e6133dd15144ca038a85a9cd5026bb06d6bbae9e77440dc9", size = 253301, upload-time = "2026-07-02T13:08:49.5Z" },
+    { url = "https://files.pythonhosted.org/packages/72/28/d2c841d698bf762e481f08bd4839d370246b6d9b61dab085a7b20b201a08/coverage-7.15.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1ac2c4c27c7df851dc9a017c2d7de00b69147e84ba3d96f37a530b0b6fb51035", size = 251361, upload-time = "2026-07-02T13:08:51.304Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ed/55d9ffde994fba3897c0c783f77a7d053b0c18787f6892ed5b0aed73f469/coverage-7.15.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b761a1d504fd4bd1f20f418753964dca9f5862a511fc854dac58296b3b223671", size = 255129, upload-time = "2026-07-02T13:08:52.661Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c0/ecbf33b8c460ea2718aeb813e2df8140d0370e5f67261c31524ceb0a2a8d/coverage-7.15.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e43b045e11c16e897895758ae90e4a90cf99e93d58549e2f90c0e2272e155695", size = 251081, upload-time = "2026-07-02T13:08:54.188Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/de/fb87b4261f54448dd2b9504ef19a58be42cef0d9520595fbfe1219b15234/coverage-7.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:589b54513e901739f4b4582c705ce96b80c96f57641b1464607e2367a270e540", size = 251988, upload-time = "2026-07-02T13:08:55.726Z" },
+    { url = "https://files.pythonhosted.org/packages/df/27/3494d5f291b9a4cb868f73c11221a8bd2d5bd761a8f9acea61ff57128dd1/coverage-7.15.0-cp311-cp311-win32.whl", hash = "sha256:106781b8482749162d0b47056937ba0933508e5d9447f65a5e7d5c422f0d6bb4", size = 222754, upload-time = "2026-07-02T13:08:57.091Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/ee/cd4847ebc9be6a9c0123d763645a6f1f3be6b8c58c962706368b79cbac07/coverage-7.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:821e92b3631d762a339695824cadbbc73020354eba2a23a551a99ad34938fbe6", size = 223225, upload-time = "2026-07-02T13:08:58.594Z" },
+    { url = "https://files.pythonhosted.org/packages/57/37/5011581aa7f2be498b97dcc7c9902192442a42f4f9a748aeadb3d6506b42/coverage-7.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:309990eb5fb8014b9f67cb211f7fd41876ec8a88a88d3ae76de0ed1d611e3640", size = 222774, upload-time = "2026-07-02T13:09:00.074Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/74/fd4c0901137c4f8d81a76ada99e43c65163b4c94a02ece107a4ec0c6b615/coverage-7.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b75ee5e8cb7575636ac598719b4307ac529ec8fcd79608a35c3cd4d4dada812d", size = 220838, upload-time = "2026-07-02T13:09:02.084Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2e/2347583467bd7f0402635101a916961915cc68fce652cd0db5f173ea04fc/coverage-7.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffb31267816b93b075302248cc1737506081b4f163df4401e9df1a6424aafabe", size = 221197, upload-time = "2026-07-02T13:09:03.617Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/17/99fa688541ae1d6e84543a0e544f83de0c944815b63e9e7b1ed411d15036/coverage-7.15.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4d0bb73455bf97ab243a8f12c37c686ccf1c13bb614b7b85f1d062f06f42b2c", size = 252705, upload-time = "2026-07-02T13:09:05.059Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/02/6a95a5cd83b74839017ef9cf48d2d8c9ae60af919e17a3f336e6f9f1b7bd/coverage-7.15.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:20d9ccc4ebd0edc434d86dfd2a1dd2a8efa6b6b3073d0485a394fee86459ebb4", size = 255441, upload-time = "2026-07-02T13:09:06.559Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f2/406f6c57d600f68185942422c4c00f1a3255d60aee6e5fd961425cd9987e/coverage-7.15.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20c8a976c365c8cb12f0cbd099508772ea41fb5fa80657a8506df0e11bd278c5", size = 256556, upload-time = "2026-07-02T13:09:08.197Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8e/d3fa48489c15ecdec1ba48fd61f68798555dddd2f6716f9ad42adeb1a2a9/coverage-7.15.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f948fd5ba1b9cbca91f0ae08b4c1ce2b139509149a435e2585d056d57d70bf01", size = 258815, upload-time = "2026-07-02T13:09:09.691Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2e/2d40ddd110462c6a2769677cf7f1c119a52b45f568978fc6c98e4cc0dd0f/coverage-7.15.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f58185f06edf6ad68ec9fb155d63ef650c82f3fbd7e1770e2867751fb13158f4", size = 253117, upload-time = "2026-07-02T13:09:11.212Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c0/310782f0d7c3cb2b5ac05ba8d205fe91f24a36f6bf3256098f1782181c38/coverage-7.15.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:02adc79a920c73c647c5d117f55747df7f2de94571884758ce8bc58e04f0a796", size = 254475, upload-time = "2026-07-02T13:09:13.029Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f7/702da6c275f8ae6ade423d2877243122932c9b27f5403003b9ef8c927d12/coverage-7.15.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6eb7c300fbed667fd6e3588eba71c1904cdb06110ca6fdf908c26bdd88b8e382", size = 252619, upload-time = "2026-07-02T13:09:14.699Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/84/c5b15a7e5ecba4e56218d772d99fe80a63e63f8d11f12783723a6005ab45/coverage-7.15.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b5fb23fa2de9dce1f5c36c09066d8fcda16cd96e8e26686caa2d7cb9b567d65c", size = 256689, upload-time = "2026-07-02T13:09:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2f/c8b07559b57701230c61b23a953858c052890c12ef568d81780c6c46e92e/coverage-7.15.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cec79341dbe6281484024979976d0c7f22beae08b4a254655decd25d42cbe766", size = 252189, upload-time = "2026-07-02T13:09:17.828Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/80/6d2f049dd3fd3dbfd60b62ba6b2162a04009e2c002ce70b24cf3878dec7a/coverage-7.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c664c5444b1d970b1b2a450e21fb19ee5c9cfdf151ded2dda37260031cca0da", size = 254059, upload-time = "2026-07-02T13:09:19.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/92/b0287a2c42031d25c628f815f89a3cd9f8268ee78bb1252c9356cda1c689/coverage-7.15.0-cp312-cp312-win32.whl", hash = "sha256:5f764a3fa339bde6b3aa97657f5a6a3a9451e4a5b4ea98a2892c773a43525f77", size = 222893, upload-time = "2026-07-02T13:09:20.812Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/69/e34c481915fecb499b3146975061dac528752e37706edc1804f32c822469/coverage-7.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:52f9a4d2c4c56c8848bc2f524916698354b0211488b38c49ad9ae54f6cafbff6", size = 223429, upload-time = "2026-07-02T13:09:22.315Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/98/6e878f0b571d32684ef3f38d7c03db241ca5b82a5da8a5391596a8f209c4/coverage-7.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:31e5c3e70c85307ea35a12964e2e40f56ca2ee4b1c8c721ccf4609d17071080b", size = 222810, upload-time = "2026-07-02T13:09:23.812Z" },
+    { url = "https://files.pythonhosted.org/packages/76/04/145a3748098bcc86b631a85408d2c3dc5c104e0bd86d605468239b25b6c4/coverage-7.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5be4caf3b28836f078abe700f8944dac4a65d78f16d6c600c89cb624e5535782", size = 220863, upload-time = "2026-07-02T13:09:25.371Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5c/4ed55708fed2c64b63c9bc5715daef670872202101938869b7fe5d5fbb8f/coverage-7.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd58ad1404704303ca8d4f4b8a1095e7cbc7040ef17a66df1e6619aa10176430", size = 221230, upload-time = "2026-07-02T13:09:26.897Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/19/3a80b97d3b2a5c77a01ae359c6bed20c13738fe3d9380f08616d4fec0281/coverage-7.15.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bbcbb317c2e5ded5b21104af81c29f391be2af98d065693ffbe8d23949b948e5", size = 252227, upload-time = "2026-07-02T13:09:28.543Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/b70062750686bd7da454da27927622f48bbac6990ac7a4c4a4653e7b0036/coverage-7.15.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:27f31ecb458da3f859aab3f15ada871eb7a7768807d88df4a9f186bb17737970", size = 254823, upload-time = "2026-07-02T13:09:30.177Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/09/dad6a75a2e561b9dc5086a8c5257a7591d584246f67e23e70d2995b89ab6/coverage-7.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fb759be317fdc62e0f56bffdf61cfcb45c7761ad6b71e3e583e71a67ae753c", size = 256059, upload-time = "2026-07-02T13:09:31.979Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e7/b5d2941fa9564573d44b693a871ff3156f0c42cbefe977a09fa7fdc59971/coverage-7.15.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5cf007add5ab4bb8fa9f4c77e3732127c9e6cad501d7db43355fbfafca0be84", size = 258190, upload-time = "2026-07-02T13:09:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/1d/8e895bcde3c57ccd46d896dda5f2b3d5df761a1b0c6c9d450d175dedc632/coverage-7.15.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc78d9843bd576fbe2118248258d485e968dc535f95ed504a7b0867ba9b51389", size = 252456, upload-time = "2026-07-02T13:09:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4c/f6997da343ddeb959be82c3b05322793f92c071ad45f7cb8a96336e2dd5f/coverage-7.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a263060f1de0b4b74b4e089c2a70b8003b3781c733329a9c8fd54995328f9950", size = 254192, upload-time = "2026-07-02T13:09:37.445Z" },
+    { url = "https://files.pythonhosted.org/packages/17/27/a0bc09d032267b9da89d95a2d874cfbef2a5aebbf0e87cf7aba221d79a99/coverage-7.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c48decf16e0dfd5b049c7d5e82200c23c08126719142998d4f172444e3d0529e", size = 252153, upload-time = "2026-07-02T13:09:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/54/c0/77fc233d9fba07b244c40948c53fe27308b8f21732fb3417f87fbd6fd992/coverage-7.15.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:08fb028000ed0aaa0a4cbdfbb98be7cb42f370db973fbbb469733505ab20e13e", size = 256310, upload-time = "2026-07-02T13:09:41.006Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/24/601cecfb5825becacb8d45219a018a3b55b9dbaec624efdb0ea249d08be2/coverage-7.15.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb7dc0c3b7d8a1077abea0b8546ebc5e26d6ef6ecefc2f0f5ad2b8a53bdad837", size = 251974, upload-time = "2026-07-02T13:09:42.733Z" },
+    { url = "https://files.pythonhosted.org/packages/47/1e/6f45e5a5b3d5484318d368702af6716b5ab8913b0428bec981a562fcf296/coverage-7.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cb3602054ccbe9f0d8c2dc04bbeba90d5719236e2cd06e042ddd6d3fc7b6e37", size = 253745, upload-time = "2026-07-02T13:09:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/db/4df027a77bd11d0e527f44c53557c76e54ad027413d0304252ea3a78d67e/coverage-7.15.0-cp313-cp313-win32.whl", hash = "sha256:0bf781da64326b677be344df505171435b6f58716108606621d5d27d964fff8b", size = 222902, upload-time = "2026-07-02T13:09:46.122Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/10/0355894d34e231f2c5449e71287e81a50793a325df2e2b027b7bcd9dfd19/coverage-7.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:2c57a275078ee3fa185f83e400f765bc764a549de66d99b47881645cbd4ea629", size = 223444, upload-time = "2026-07-02T13:09:47.687Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ef/bb725f263befaaff851203ab338e68af15e195d7f7b5f323162532d9b6a8/coverage-7.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:3812c61afc6685c7999b39320779ab8f43b7a3081fdb0def39976e56fbdb9a21", size = 222839, upload-time = "2026-07-02T13:09:49.717Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/9c/1e3ca54f72a3185ece06c58d871099898c48f0ed6430d17b6ab75f0d180a/coverage-7.15.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:41cb79af843222e11da87127ad0ecbfa878abadd0f770a4a99391a27d3887324", size = 220906, upload-time = "2026-07-02T13:09:51.339Z" },
+    { url = "https://files.pythonhosted.org/packages/09/37/f718613d83b274880382f6b67e78f3802549ae39b0b3e65ae5b5974df56e/coverage-7.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7d2008989ef8fe54188d3f3bfa2e3099b025af11e90a6a1b9e7dc433d04263d8", size = 221239, upload-time = "2026-07-02T13:09:53.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/22bae91e0b75445f68d365c7643ed0aa4880bbf77450ee74ca65bdae53a7/coverage-7.15.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:769e8ece11a596315ebf5aa7ec383aeeed016c091d2bf6363ffb996d41529092", size = 252286, upload-time = "2026-07-02T13:09:54.996Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1e/bec5e32aa508615d9d7a2790effb25fb4dc28606e995816afe400b25ece3/coverage-7.15.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:65a6b6164ee5c39e2f3803f314292d6c61a607ba7fee253d1e03c42dc3903502", size = 254789, upload-time = "2026-07-02T13:09:56.678Z" },
+    { url = "https://files.pythonhosted.org/packages/17/29/0e865435b4354e4a7c03b1b7920046d31d0a273d55decefea27e011cb9bf/coverage-7.15.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75128817f95a5c45bb01d65fd2d8b9cb54bbe03d81608fb70e3e14b437ad56c2", size = 256135, upload-time = "2026-07-02T13:09:58.343Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ff/33a870b58a13325d62fc0a6c8f01fa0ff667cef60c7498e2382a147dfa18/coverage-7.15.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9887bb428fe2d4cd4bee89bac1a6c9932f484afd5b36fbd4ff6ea5f825bb1f5e", size = 258449, upload-time = "2026-07-02T13:10:00.057Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7b/6fffe596bf3ddba8462758d02c5dad730fd91055a6634aa2e4226229181a/coverage-7.15.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0bfc0be1f702042207a93a00523b1065ee1fe951e96edf311581c0bbc2e34888", size = 252313, upload-time = "2026-07-02T13:10:01.946Z" },
+    { url = "https://files.pythonhosted.org/packages/58/1b/11468dd6c1676ab831a70cb9a8d4e198e8607fa0b7220ab918b73fe9bfbd/coverage-7.15.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f64627d55def5a43282d70e08396672692f77e4da610a5bb8bb4060b432b6859", size = 254142, upload-time = "2026-07-02T13:10:04.065Z" },
+    { url = "https://files.pythonhosted.org/packages/79/41/29328e21d16b1b95092c30dd700e08cf915bd3734f836df8f3bdb0e8fa9f/coverage-7.15.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:2c6f0fa473003905c6d5bac328ee4eba9fbea654f15bc24b8a3274b23363fa99", size = 252108, upload-time = "2026-07-02T13:10:06.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/de/05ccfb990439655b35afbfd8e0d13fe66677565a7d4eb38c3f5ef2635e1c/coverage-7.15.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2bcf9afaf064172c6ec3c58a325a9957ad1178c05dd934e25f253321776e0676", size = 256385, upload-time = "2026-07-02T13:10:08.141Z" },
+    { url = "https://files.pythonhosted.org/packages/51/0e/486828a3d2695ea7a2609f17ff572f6b01905e608379440a11da4b8dffbe/coverage-7.15.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:baf06bc987115d6fb938d403f7eab684a057766c490367999a2b71a6883110c6", size = 251923, upload-time = "2026-07-02T13:10:10.179Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c7/03582b6715f078e5e558354c87616d945b9894cda2dace8e4009b17035e4/coverage-7.15.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0405f2ff97b1c4c0e782cb32e02f32369bcf2e6b618b591d67e1ea754575dfe", size = 253580, upload-time = "2026-07-02T13:10:12.052Z" },
+    { url = "https://files.pythonhosted.org/packages/db/dc/9e578bbaf2ecb4959a81b7e7601ad8cca772cba2892e8d144cb749b4a71a/coverage-7.15.0-cp314-cp314-win32.whl", hash = "sha256:ab282853ed5fbd64bbb162f19cb8fcb7087187508a6374b4f9c34ec1577c4e8f", size = 223107, upload-time = "2026-07-02T13:10:13.994Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3e/c8c3b75d8dbe0e35f7b0cc3ff5e949fc59500f70b21d0398813f66740664/coverage-7.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bb3040e9f4bbe26fcb0cd7cc85ac63e630d3f3a9c74f027abf4caa27e706663", size = 223597, upload-time = "2026-07-02T13:10:15.906Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/bc/3cbc9fb036eb388519bccd521f783499c39b64256013fbc362782f196fe1/coverage-7.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:346771144d34f7fa84ec28386f78e0f31653f33cf35e19d253d5b35f9e8201da", size = 223020, upload-time = "2026-07-02T13:10:17.844Z" },
+    { url = "https://files.pythonhosted.org/packages/28/00/199c4a8d656dff63102577a056c0fce2ff6a79e40adac092fc986c49cbf1/coverage-7.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d34a010905fb6401324ba016b5da03d574967f7b21ce48ea41e66f0f1f95f641", size = 221638, upload-time = "2026-07-02T13:10:19.703Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8e/9d0092c96a3d3a26951ecc7020826aa57bcb1b119ca81acbba996884ab13/coverage-7.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bb25d825d885ca8036795dacfc3924d33091fc76d71ebc99420c6b79e77d96fa", size = 221903, upload-time = "2026-07-02T13:10:21.514Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b4/c0ca3028f42c9a08e51feb4561ef1192e5de99797cd1db5b04590c215bda/coverage-7.15.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:94c9686bfe8a9a6810297aecbd99beaa3445f9e8dc2f80b1382cca0d86b64461", size = 263267, upload-time = "2026-07-02T13:10:23.261Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/aa/a375e3846e5d3c013dc600b2a3231089055c73d77f5393dd2192a8d64da6/coverage-7.15.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9bd671c25f9d85f09d7ec481d0e43d5139f486c06a37139847a7ce569788af72", size = 265390, upload-time = "2026-07-02T13:10:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e1/5783cdabb797305e1c9e4809fea496d31834c51fa772514f73dc148bcfc9/coverage-7.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:110cbdf8d2e216577312cf06ccf85539c0e5a5420ef747e4a4719b5e483c88cd", size = 267811, upload-time = "2026-07-02T13:10:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/85/31/96d8bbf58b8e9193bc8389574a91a0db48355ee98feb66aa6bf8d1b32eea/coverage-7.15.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2c5d4619214f1d9993e7b00a8600d14614b7e9d84e89507460b126aa5e6559e5", size = 268928, upload-time = "2026-07-02T13:10:29.242Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7a/5294567e811a1cb7eda93140c628fa050d66189da28da320f93d1d815c73/coverage-7.15.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:781a704516e2d8346fbbd5be6c6f3412dd824785146528b3a01816f26c081007", size = 262378, upload-time = "2026-07-02T13:10:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3f/3f48538421f899f28946f90a3d272136a4686e1abf461cc9249a783ee0f3/coverage-7.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd4a1b44bcb65ee29e947ac92bbee04956df3a6bfc6143641bb6cae7ede00fc9", size = 265263, upload-time = "2026-07-02T13:10:32.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d3/092df15efcab8a9c1467ee960eb8019bbad3f9300d115d89ea6195f369ff/coverage-7.15.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0e4950c9d6d3e39c64c991814ff315e2d0b9cb8152363594212c9e55208c0a8f", size = 262866, upload-time = "2026-07-02T13:10:35.104Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ab/0254d2b88665efb2c57ad368cc77ab5de3435bd8d5add4729c1b0e79431e/coverage-7.15.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:fe9c87ff42e5472d80d21704972e1f96e104a0a599d77c5e35db5a3c562e2571", size = 266599, upload-time = "2026-07-02T13:10:37.05Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/79/1cfa4023e489ce6fbc7be4a5d442dbc375edb4f4fda39a352cedb53263c2/coverage-7.15.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f00d5ae1dd2fe13fb8186e3e7d37bcbd8b25c0d764ff7d1b32cef9be058510a8", size = 261714, upload-time = "2026-07-02T13:10:38.966Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/eb/fee5c8665656be63f497418d410484637c438172568688e8ac92e06574e7/coverage-7.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:363ab38cc78b615f11c9cac3cf1d7eef950c18b9fdedfb9066f59461dcf84d68", size = 264025, upload-time = "2026-07-02T13:10:40.789Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/99/63005db722f91edc81abc16302f9cc2f6228c1679e46e15be9ae144b14d0/coverage-7.15.0-cp314-cp314t-win32.whl", hash = "sha256:54fd9c53a5fafff509195f1b6a3f9be615d8e8362a3629ff1de23d270c03c86b", size = 223413, upload-time = "2026-07-02T13:10:42.597Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/e8/2bc6181c4fb06f1a6b981eb85330cc57bfad7e3f710fc9c9d350013ba228/coverage-7.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:87b47553097ba185ed964866078e7e63adea9f5f51b5f39691c34f30afd21080", size = 224245, upload-time = "2026-07-02T13:10:44.47Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b8/4d959bf9cc45d0cfed2f4d35cafcab978cdb6ea02eb5100009cd740632a3/coverage-7.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aeefb2dd178fe7eee79f0ad25d75855cb35ee9ed472db2c5ea06f5b4fd00cec5", size = 223558, upload-time = "2026-07-02T13:10:46.368Z" },
+    { url = "https://files.pythonhosted.org/packages/52/30/21b2ad45959cd50e909e02ebac1e30b4ceb7162e91c11d4c570223a458b7/coverage-7.15.0-py3-none-any.whl", hash = "sha256:56da6a4cbe8f7e9e80bd072ca9cefe67d7106a440a7ec06519ec6507ac94ad19", size = 212632, upload-time = "2026-07-02T13:10:48.641Z" },
 ]
 
 [package.optional-dependencies]
@@ -487,27 +474,27 @@ toml = [
 
 [[package]]
 name = "debugpy"
-version = "1.8.20"
+version = "1.8.21"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/aa/12037145b7a56eaa5b29b41872f7a21b538e807e13f32c4d3c46e59be084/debugpy-1.8.21.tar.gz", hash = "sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6", size = 1697577, upload-time = "2026-06-01T19:30:35.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/56/c3baf5cbe4dd77427fd9aef99fcdade259ad128feeb8a786c246adb838e5/debugpy-1.8.20-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:eada6042ad88fa1571b74bd5402ee8b86eded7a8f7b827849761700aff171f1b", size = 2208318, upload-time = "2026-01-29T23:03:36.481Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/7d/4fa79a57a8e69fe0d9763e98d1110320f9ecd7f1f362572e3aafd7417c9d/debugpy-1.8.20-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:7de0b7dfeedc504421032afba845ae2a7bcc32ddfb07dae2c3ca5442f821c344", size = 3171493, upload-time = "2026-01-29T23:03:37.775Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/f2/1e8f8affe51e12a26f3a8a8a4277d6e60aa89d0a66512f63b1e799d424a4/debugpy-1.8.20-cp311-cp311-win32.whl", hash = "sha256:773e839380cf459caf73cc533ea45ec2737a5cc184cf1b3b796cd4fd98504fec", size = 5209240, upload-time = "2026-01-29T23:03:39.109Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/92/1cb532e88560cbee973396254b21bece8c5d7c2ece958a67afa08c9f10dc/debugpy-1.8.20-cp311-cp311-win_amd64.whl", hash = "sha256:1f7650546e0eded1902d0f6af28f787fa1f1dbdbc97ddabaf1cd963a405930cb", size = 5233481, upload-time = "2026-01-29T23:03:40.659Z" },
-    { url = "https://files.pythonhosted.org/packages/14/57/7f34f4736bfb6e00f2e4c96351b07805d83c9a7b33d28580ae01374430f7/debugpy-1.8.20-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:4ae3135e2089905a916909ef31922b2d733d756f66d87345b3e5e52b7a55f13d", size = 2550686, upload-time = "2026-01-29T23:03:42.023Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/78/b193a3975ca34458f6f0e24aaf5c3e3da72f5401f6054c0dfd004b41726f/debugpy-1.8.20-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:88f47850a4284b88bd2bfee1f26132147d5d504e4e86c22485dfa44b97e19b4b", size = 4310588, upload-time = "2026-01-29T23:03:43.314Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/55/f14deb95eaf4f30f07ef4b90a8590fc05d9e04df85ee379712f6fb6736d7/debugpy-1.8.20-cp312-cp312-win32.whl", hash = "sha256:4057ac68f892064e5f98209ab582abfee3b543fb55d2e87610ddc133a954d390", size = 5331372, upload-time = "2026-01-29T23:03:45.526Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/39/2bef246368bd42f9bd7cba99844542b74b84dacbdbea0833e610f384fee8/debugpy-1.8.20-cp312-cp312-win_amd64.whl", hash = "sha256:a1a8f851e7cf171330679ef6997e9c579ef6dd33c9098458bd9986a0f4ca52e3", size = 5372835, upload-time = "2026-01-29T23:03:47.245Z" },
-    { url = "https://files.pythonhosted.org/packages/15/e2/fc500524cc6f104a9d049abc85a0a8b3f0d14c0a39b9c140511c61e5b40b/debugpy-1.8.20-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5dff4bb27027821fdfcc9e8f87309a28988231165147c31730128b1c983e282a", size = 2539560, upload-time = "2026-01-29T23:03:48.738Z" },
-    { url = "https://files.pythonhosted.org/packages/90/83/fb33dcea789ed6018f8da20c5a9bc9d82adc65c0c990faed43f7c955da46/debugpy-1.8.20-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:84562982dd7cf5ebebfdea667ca20a064e096099997b175fe204e86817f64eaf", size = 4293272, upload-time = "2026-01-29T23:03:50.169Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/25/b1e4a01bfb824d79a6af24b99ef291e24189080c93576dfd9b1a2815cd0f/debugpy-1.8.20-cp313-cp313-win32.whl", hash = "sha256:da11dea6447b2cadbf8ce2bec59ecea87cc18d2c574980f643f2d2dfe4862393", size = 5331208, upload-time = "2026-01-29T23:03:51.547Z" },
-    { url = "https://files.pythonhosted.org/packages/13/f7/a0b368ce54ffff9e9028c098bd2d28cfc5b54f9f6c186929083d4c60ba58/debugpy-1.8.20-cp313-cp313-win_amd64.whl", hash = "sha256:eb506e45943cab2efb7c6eafdd65b842f3ae779f020c82221f55aca9de135ed7", size = 5372930, upload-time = "2026-01-29T23:03:53.585Z" },
-    { url = "https://files.pythonhosted.org/packages/33/2e/f6cb9a8a13f5058f0a20fe09711a7b726232cd5a78c6a7c05b2ec726cff9/debugpy-1.8.20-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9c74df62fc064cd5e5eaca1353a3ef5a5d50da5eb8058fcef63106f7bebe6173", size = 2538066, upload-time = "2026-01-29T23:03:54.999Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/56/6ddca50b53624e1ca3ce1d1e49ff22db46c47ea5fb4c0cc5c9b90a616364/debugpy-1.8.20-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:077a7447589ee9bc1ff0cdf443566d0ecf540ac8aa7333b775ebcb8ce9f4ecad", size = 4269425, upload-time = "2026-01-29T23:03:56.518Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/d9/d64199c14a0d4c476df46c82470a3ce45c8d183a6796cfb5e66533b3663c/debugpy-1.8.20-cp314-cp314-win32.whl", hash = "sha256:352036a99dd35053b37b7803f748efc456076f929c6a895556932eaf2d23b07f", size = 5331407, upload-time = "2026-01-29T23:03:58.481Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d9/1f07395b54413432624d61524dfd98c1a7c7827d2abfdb8829ac92638205/debugpy-1.8.20-cp314-cp314-win_amd64.whl", hash = "sha256:a98eec61135465b062846112e5ecf2eebb855305acc1dfbae43b72903b8ab5be", size = 5372521, upload-time = "2026-01-29T23:03:59.864Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/cbf306d6e07a313a91e7171a98669054502840931432c227cfd505ee367f/debugpy-1.8.21-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:da456226c7b4c69e35dbe35dcee6623d912000a77816db7856a41af1c72a0264", size = 2203120, upload-time = "2026-06-01T19:30:43.964Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/57/aa739bd4ad2cbf96aeb1b20b56918ddd5ae4c28b68709bfcd327f02123ee/debugpy-1.8.21-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:f68b891688e61bdc08b8d364d919ff0051e0b94657b39dcd027bc3173edb7cdc", size = 3059958, upload-time = "2026-06-01T19:30:45.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/31/453d2c9a23d133fe2c8ec7ca1d816ded52a913487fe3ffef7c01b4b706af/debugpy-1.8.21-cp311-cp311-win32.whl", hash = "sha256:f843a8b08c2edeaf9b1582eed4f25441af21a297c22ff16bf76a662557aa9c9e", size = 5236515, upload-time = "2026-06-01T19:30:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/6660de2f2d7bf388f229335ba4637646eebabdbf38564cb439a95a9193c9/debugpy-1.8.21-cp311-cp311-win_amd64.whl", hash = "sha256:84c564d8cc701d41843b29a92814c1f1bef6798724ca9d675c284ad9f6a547d7", size = 5256138, upload-time = "2026-06-01T19:30:49.113Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/df/bf625547431a9cadc9f4cbfeda38866e2b17f6aed147b625377e87834449/debugpy-1.8.21-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:9f96713896f39c3dff0ee841f47320c3f2983d33c341e009361bb0ebc79adc4e", size = 2483609, upload-time = "2026-06-01T19:30:50.794Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/59324b903599031ff9faaec1758292409f6561a0ec2492fe4b703327705a/debugpy-1.8.21-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:c193d474f0a211191f2b4449d2d06157c689013035bd952f3b617e0ef422b176", size = 3968900, upload-time = "2026-06-01T19:30:52.341Z" },
+    { url = "https://files.pythonhosted.org/packages/14/cd/27f65b805d7fe005c44e1a36b9183ecdfbcdbf9d3e721a5115d461ecc7ee/debugpy-1.8.21-cp312-cp312-win32.whl", hash = "sha256:4743373c1cac7f9e74a1b9915bf1dbe0e900eca657ffb170ae07ac8363205ae9", size = 5336340, upload-time = "2026-06-01T19:30:54.047Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1d/c84e30c0c674184948b66f076ab271c01d940618a2824c23cd035a27bc20/debugpy-1.8.21-cp312-cp312-win_amd64.whl", hash = "sha256:bd7ba9dd3daa7c2f942c6ca8d4695a16bf9ac16b63615261c7982bc74f7ed20c", size = 5374751, upload-time = "2026-06-01T19:30:55.891Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6b/d817e1f8cc77aa055d37fba092e0febfdff40fe652d8d53d4cd7a86ad98d/debugpy-1.8.21-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:13678151fc401e2d68c9880b91e28714f797d40422994572b24560ef80910a88", size = 2477398, upload-time = "2026-06-01T19:30:57.644Z" },
+    { url = "https://files.pythonhosted.org/packages/48/57/412421516afc3055fa577516f00beec3d663f9b0ab330639547ae6c57720/debugpy-1.8.21-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:ecbd158386c31ffe71d46f72d44d56e66331ab9b16cad649156d514368f23ab2", size = 3962096, upload-time = "2026-06-01T19:30:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2c616337cf6ba7b07ebbc97f02c6c945a8e2f76b365e33ee809c32ee36d1/debugpy-1.8.21-cp313-cp313-win32.whl", hash = "sha256:2c2ae706dec41d99a9ca1f7ebc987a83e65578363be6f6b3ac9067504917fae1", size = 5336288, upload-time = "2026-06-01T19:31:00.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/99/9175103392f84c4b1bf7622888cdc68da07f0ff7d9e581266428f6776033/debugpy-1.8.21-cp313-cp313-win_amd64.whl", hash = "sha256:aa648733047443eb1d07682c4ef287d36a54507b643ffdf38b09a3ef002c72a0", size = 5376567, upload-time = "2026-06-01T19:31:02.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3d/f4bbb323a548bfab2af3d6b4ffd9bf22636e55956a1285d317a1de643aad/debugpy-1.8.21-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9bb2a685287a2ac9b181cde89edcec64845cb51de7faaa75badb9a698bc24782", size = 2477209, upload-time = "2026-06-01T19:31:04.157Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2d/6e7ec524984a1702777868de49a4c53202bddac2a432a76a093469587750/debugpy-1.8.21-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:3d6922439bf33fd38a3e2c447869ebc7b97da5cd3d329ff1ef9bc06c4903437e", size = 3927115, upload-time = "2026-06-01T19:31:05.863Z" },
+    { url = "https://files.pythonhosted.org/packages/97/47/d1aa6d64005a98a9144647d99306b419396f9ad7bf1d73c119e17a81fb4d/debugpy-1.8.21-cp314-cp314-win32.whl", hash = "sha256:15d4963bd5ffa48f0da0947fd06757fa7621945048a14ad7705431566d3c0e7c", size = 5336724, upload-time = "2026-06-01T19:31:07.711Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/b905b90d163af11878c1af8abafa4a25206335e112e284e413454543a6da/debugpy-1.8.21-cp314-cp314-win_amd64.whl", hash = "sha256:fe0744a12353406de0ae8ccff0d0a4a666f00801a3db8fd04e7a5f761cd520e8", size = 5373803, upload-time = "2026-06-01T19:31:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl", hash = "sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92", size = 5352888, upload-time = "2026-06-01T19:31:25.186Z" },
 ]
 
 [[package]]
@@ -530,11 +517,11 @@ wheels = [
 
 [[package]]
 name = "distlib"
-version = "0.4.0"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
@@ -557,11 +544,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ee/29c668c50888588c432a702f7c2e8ee8a0c9e5286028d91f170308d6b2e9/filelock-3.29.5.tar.gz", hash = "sha256:6e6034c57a00a020e767f2614a5539863f056de7e7991d6d1473aef7ff73f156", size = 68927, upload-time = "2026-07-03T03:50:31.818Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e3/f1fae3647d170919c2cf2a898e77e7d1a4e5c7cae0aed7bb4bd3f5ebff6f/filelock-3.29.5-py3-none-any.whl", hash = "sha256:8af830889ba3a0ffcefbd6c7d2af8a54012058103771f2e10848222f476a1693", size = 45073, upload-time = "2026-07-03T03:50:30.445Z" },
 ]
 
 [[package]]
@@ -587,11 +574,11 @@ wheels = [
 
 [[package]]
 name = "griffelib"
-version = "2.0.2"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
 ]
 
 [[package]]
@@ -642,11 +629,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.17"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -660,7 +647,7 @@ wheels = [
 
 [[package]]
 name = "ipykernel"
-version = "7.2.0"
+version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "appnope", marker = "sys_platform == 'darwin'" },
@@ -670,21 +657,21 @@ dependencies = [
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "matplotlib-inline" },
-    { name = "nest-asyncio" },
+    { name = "nest-asyncio2" },
     { name = "packaging" },
     { name = "psutil" },
     { name = "pyzmq" },
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/8d/b68b728e2d06b9e0051019640a40a9eb7a88fcd82c2e1b5ce70bef5ff044/ipykernel-7.2.0.tar.gz", hash = "sha256:18ed160b6dee2cbb16e5f3575858bc19d8f1fe6046a9a680c708494ce31d909e", size = 176046, upload-time = "2026-02-06T16:43:27.403Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/e4a38f579de4225a561305666f7541cdabb30075def2aa1ac17bd73c1fb5/ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09", size = 184899, upload-time = "2026-06-10T08:41:25.481Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/b9/e73d5d9f405cba7706c539aa8b311b49d4c2f3d698d9c12f815231169c71/ipykernel-7.2.0-py3-none-any.whl", hash = "sha256:3bbd4420d2b3cc105cbdf3756bfc04500b1e52f090a90716851f3916c62e1661", size = 118788, upload-time = "2026-02-06T16:43:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/02/77b271f5dc58bfbc0b577c877b2365d1ffea2afe66a80c13f2312820348c/ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057", size = 120583, upload-time = "2026-06-10T08:41:23.648Z" },
 ]
 
 [[package]]
 name = "ipython"
-version = "9.14.0"
+version = "9.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -694,15 +681,15 @@ dependencies = [
     { name = "matplotlib-inline" },
     { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
     { name = "prompt-toolkit" },
-    { name = "psutil", marker = "sys_platform != 'emscripten'" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
     { name = "pygments" },
     { name = "stack-data" },
     { name = "traitlets" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/c2/c0064cf15d026501a1ef70e42efd9c3f818663089399aacc5e37a82901c1/ipython-9.14.0.tar.gz", hash = "sha256:6f27ff0f1d9ea050e0551f71568bc4b34d8aba579e8f111c5b4175f44ac6b4aa", size = 4432601, upload-time = "2026-05-29T15:13:24.611Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a3/9e59340f02c1dc8f8c0a05b09244712b8609eb5439f9996e887e2b82f452/ipython-9.14.0-py3-none-any.whl", hash = "sha256:8fd984a3372c14b12790b084ba6b5cff5678c0cb063244a0034f06a51f20d6c2", size = 627457, upload-time = "2026-05-29T15:13:22.942Z" },
+    { url = "https://files.pythonhosted.org/packages/40/3a/948263ca3b9d65bb2b1b0c521b3a49fad5d59ada58724bd87d2bd5ff3f36/ipython-9.15.0-py3-none-any.whl", hash = "sha256:515ad9c3cdf0c932a5a9f6245419e8aba706b7bd03c3e1d3a1c83d9351d6aa6e", size = 630895, upload-time = "2026-06-26T11:03:33.809Z" },
 ]
 
 [[package]]
@@ -755,11 +742,11 @@ wheels = [
 
 [[package]]
 name = "json5"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/4b/6f8906aaf67d501e259b0adab4d312945bb7211e8b8d4dcc77c92320edaa/json5-0.14.0.tar.gz", hash = "sha256:b3f492fad9f6cdbced8b7d40b28b9b1c9701c5f561bef0d33b81c2ff433fefcb", size = 52656, upload-time = "2026-03-27T22:50:48.108Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/42/cf027b4ac873b076189d935b135397675dac80cb29acb13e1ab86ad6c631/json5-0.14.0-py3-none-any.whl", hash = "sha256:56cf861bab076b1178eb8c92e1311d273a9b9acea2ccc82c276abf839ebaef3a", size = 36271, upload-time = "2026-03-27T22:50:47.073Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
 ]
 
 [[package]]
@@ -812,8 +799,21 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-builder"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/45/d0df8b43c10a61529c0f4a8af5e19ebe108f0c3af8f57e0fc358969907af/jupyter_builder-1.0.2.tar.gz", hash = "sha256:6155d78a5325010532a6419ffcba89eac643fd1aa56ea83115e661924d6f6aab", size = 968638, upload-time = "2026-06-12T02:33:25.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/b6/c418e0b3256f67c04933566b80bfce947350682db92c4b786a8653db32d6/jupyter_builder-1.0.2-py3-none-any.whl", hash = "sha256:b024f65d36e1d530542db597b00dd513261aa59842e0d0fbbb1015a9f1935e9c", size = 910789, upload-time = "2026-06-12T02:33:23.317Z" },
+]
+
+[[package]]
 name = "jupyter-client"
-version = "8.8.0"
+version = "8.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-core" },
@@ -821,10 +821,11 @@ dependencies = [
     { name = "pyzmq" },
     { name = "tornado" },
     { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/e4/ba649102a3bc3fbca54e7239fb924fd434c766f855693d86de0b1f2bec81/jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e", size = 348020, upload-time = "2026-01-08T13:55:47.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/dc/5512503b088997c2250b8bf18258fba9d9ce5ead641183700960d3c9d342/jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa", size = 359256, upload-time = "2026-06-09T13:15:01.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl", hash = "sha256:f93a5b99c5e23a507b773d3a1136bd6e16c67883ccdbd9a829b0bbdb98cd7d7a", size = 107371, upload-time = "2026-01-08T13:55:45.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6f/56d39bf385c5c27988aebaf0c18a2a17e960575740100973511018bd904e/jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81", size = 109828, upload-time = "2026-06-09T13:14:58.835Z" },
 ]
 
 [[package]]
@@ -873,7 +874,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-server"
-version = "2.19.0"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -896,9 +897,9 @@ dependencies = [
     { name = "traitlets" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/a0/eb3c511f54df7b54ca5fc7bff3f4d2277d69052d6a7f521643dfed5279d6/jupyter_server-2.19.0.tar.gz", hash = "sha256:1731236bc32b680223e1ceb9d68209a845203475012ef68773a81434b46a31a7", size = 754561, upload-time = "2026-05-29T11:21:26.057Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/dc/db3a582633170186f8c8b31298d7eb26ad0eb031a1f53476c258b64eed05/jupyter_server-2.20.0.tar.gz", hash = "sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14", size = 756523, upload-time = "2026-06-17T12:09:09.435Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/78/d2881e68894cecdcd05912a9c585cfb776ef1fb38b62c8dba98f12ab3adc/jupyter_server-2.19.0-py3-none-any.whl", hash = "sha256:cb76591b76d7093584c2ad2ae72ac3d58614a4b597507a1bb04e1f9f683cf9ea", size = 392244, upload-time = "2026-05-29T11:21:23.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl", hash = "sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc", size = 393143, upload-time = "2026-06-17T12:09:07.234Z" },
 ]
 
 [[package]]
@@ -916,26 +917,26 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.5.7"
+version = "4.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
     { name = "httpx" },
     { name = "ipykernel" },
     { name = "jinja2" },
+    { name = "jupyter-builder" },
     { name = "jupyter-core" },
     { name = "jupyter-lsp" },
     { name = "jupyter-server" },
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
     { name = "packaging" },
-    { name = "setuptools" },
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/22/8440ec827762146e7cdecf04335bd348795899d29dc6ae82238707353a2c/jupyterlab-4.5.7.tar.gz", hash = "sha256:55a9822c4754da305f41e113452c68383e214dcf96de760146af89ce5d5117b0", size = 23992763, upload-time = "2026-04-29T16:43:51.328Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/2a/d6af53bfd45a43a5bfe7e40ba47ee7a8921a807daf4bb708e3a295bbb54d/jupyterlab-4.6.1.tar.gz", hash = "sha256:75315982ed28427edaa62bb85eadb5105e4043a757643c910efd787fe6ed0837", size = 28179125, upload-time = "2026-06-29T12:48:45.402Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/aa/537b8f7d80e799af19af35fb3ddfc970b951088a13c57dd9387dcfbb7f61/jupyterlab-4.5.7-py3-none-any.whl", hash = "sha256:fba4cb0e2c44a52859669d8c98b45de029d5e515f8407bf8534d2a8fc5f0964d", size = 12450123, upload-time = "2026-04-29T16:43:46.639Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/81/90ac6cc31d248e83a0d1eab343a5e6e68bc783d3f74fbe61640f42a61da4/jupyterlab-4.6.1-py3-none-any.whl", hash = "sha256:85a58546c831f3dce6cf919468c26874c9065e99c42279fb4abb8e1b552a98bb", size = 17164660, upload-time = "2026-06-29T12:48:41.21Z" },
 ]
 
 [[package]]
@@ -976,75 +977,77 @@ wheels = [
 
 [[package]]
 name = "librt"
-version = "0.11.0"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/e0/dbd0f2a68a1c1a1991eb7921ff6014465d56608cdc9a9fb468a616210a37/librt-0.12.0.tar.gz", hash = "sha256:cb26faedbd09c6130e9c1b64d8000efec5076ffd18d606c6cd1cf02730e6d8b0", size = 203841, upload-time = "2026-06-30T16:14:29.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/87/2bf31fe17587b29e3f93ec31421e2b1e1c3e349b8bf6c7c313dbad1d5340/librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29", size = 141092, upload-time = "2026-05-10T18:15:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/08/5c5bf772920b7ebac6e32bc91a643e0ab3870199c0b542356d3baa83970a/librt-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ee278c769a713638cdacd4c0436d72156e75df3ebc0166ab2b9dc43acc386c9", size = 142035, upload-time = "2026-05-10T18:15:36.242Z" },
-    { url = "https://files.pythonhosted.org/packages/06/20/662a03d254e5b000d838e8b345d83303ddb768c080fd488e40634c0fa66b/librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5", size = 475022, upload-time = "2026-05-10T18:15:37.56Z" },
-    { url = "https://files.pythonhosted.org/packages/de/f3/aa81523e45184c6ec23dc7f63263362ec55f80a09d424c012359ecbe7e35/librt-0.11.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5d63c855d86938d9de93e265c9bd8c705b51ec494de5738340ee93767a686e4b", size = 467273, upload-time = "2026-05-10T18:15:39.182Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/6f/59c74b560ca8853834d5501d589c8a2519f4184f273a085ffd0f37a1cc47/librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89", size = 497083, upload-time = "2026-05-10T18:15:40.634Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/7b/5aa4d2c9600a719401160bf7055417df0b2a47439b9d88286ce45e56b65f/librt-0.11.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:258d73a0aa66a055e65b2e4d1b8cdb23b9d132c5bb915d9547d804fcaed116cc", size = 489139, upload-time = "2026-05-10T18:15:41.934Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/31/9143803d7da6856a69153785768c4936864430eec0fd9461c3ea527d9922/librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0827efe7854718f04aaddf6496e96960a956e676fe1d0f04eb41511fd8ad06d5", size = 508442, upload-time = "2026-05-10T18:15:43.206Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/5a/bce08184488426bda4ccc2c4964ac048c8f68ae89bd7120082eef4233cfd/librt-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7753e57d6e12d019c0d8786f1c09c709f4c3fcc57c3887b24e36e6c06ec938b7", size = 514230, upload-time = "2026-05-10T18:15:44.761Z" },
-    { url = "https://files.pythonhosted.org/packages/89/8c/bb5e213d254b7505a0e658da199d8ab719086632ce09eef311ab27976523/librt-0.11.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11bd19822431cc21af9f27374e7ae2e58103c7d98bda823536a6c47f6bb2bb3d", size = 494231, upload-time = "2026-05-10T18:15:46.308Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/fb/541cdad5b1ab1300398c74c4c9a497b88e5074c21b1244c8f49731d3a284/librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:22bdf239b219d3993761a148ffa134b19e52e9989c84f845d5d7b71d70a17412", size = 537585, upload-time = "2026-05-10T18:15:47.629Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/f2/464bb69295c320cb06bddb4f14a4ec67934ee14b2bffb12b19fb7ab287ba/librt-0.11.0-cp311-cp311-win32.whl", hash = "sha256:46c60b61e308eb535fbd6fa622b1ee1bb2815691c1ad9c98bf7b84952ec3bc8d", size = 100509, upload-time = "2026-05-10T18:15:49.157Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/e7/a17ee1788f9e4fbf548c19f4afa07c92089b9e24fef6cb2410863781ef4c/librt-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:902e546ff044f579ff1c953ff5fce97b636fe9e3943996b2177710c6ef076f73", size = 118628, upload-time = "2026-05-10T18:15:50.345Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/c7/6c766214f9f9903bcfcfbef97d807af8d8f5aa3502d247858ab17582d212/librt-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:65ac3bc20f78aa0ee5ae84baa68917f89fef4af63e941084dd019a0d0e749f0c", size = 103122, upload-time = "2026-05-10T18:15:52.068Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a", size = 479623, upload-time = "2026-05-10T18:15:57.544Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
-    { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766", size = 527348, upload-time = "2026-05-10T18:16:03.496Z" },
-    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
-    { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
-    { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
-    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
-    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
-    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
-    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
-    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
-    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
-    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
-    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
-    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
-    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
-    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
-    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
-    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
-    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ab/628490f42d1eba82f3c7e5821aa62013e6df7f525b7a9e92c048f8d1cc1c/librt-0.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3f13c1e8563102c2b17581cf37fcb2c6dae7ad485ccea93ae46258998c25f9a1", size = 143821, upload-time = "2026-06-30T16:12:23.248Z" },
+    { url = "https://files.pythonhosted.org/packages/38/5f/793e8b6f4b6ac16e7d7198478c0af3670606fbb535c768d5f3e954781423/librt-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d1ddff067610a122387024c4df527493b909d41e54a6e5b2d0e6c1041d6dfa09", size = 148442, upload-time = "2026-06-30T16:12:24.582Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/92/c780fe37a9e0982f3bd8fd9a631d6b95d09a5a7201c6c50366ce843b7e42/librt-0.12.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8dc7ebb5f3eec062398e9d0ef1938acd21b589e74286c4a8906d0183318d91b", size = 478276, upload-time = "2026-06-30T16:12:26.101Z" },
+    { url = "https://files.pythonhosted.org/packages/41/bb/226d444bc20d7dff4a19ec6c1ff2c13a76385eebddb59c9c00c923b67536/librt-0.12.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:198de569ea9d5f6f33808f1c00cc3db9de62bf4d6deafa3b052bd08255083038", size = 472337, upload-time = "2026-06-30T16:12:27.83Z" },
+    { url = "https://files.pythonhosted.org/packages/12/79/98ac0840ee90a75d4e1155c79062860b12ccca508587ff2119fc086965f2/librt-0.12.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e958678a8bca56016aedc891b391c0e0813ea382a874b54a2c1b313c1d232720", size = 502087, upload-time = "2026-06-30T16:12:29.443Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/72/a6b1a0d080606a7f5f646b79a1496f21d709f8563877759ace9ce5adad73/librt-0.12.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575a6eca68c8437ed4a8e0f534e31d74b562ba1049a0ee4b5f09e114bcc21be1", size = 493202, upload-time = "2026-06-30T16:12:31.077Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cf/e1b036b45f2fc272205ee18bf272b47e8d684bf1a75af26db440c7504359/librt-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:86f241c50dc9e9a3f0db6dbb37a607c8205aa87b920802dabbd50b70d40f6939", size = 514139, upload-time = "2026-06-30T16:12:33.032Z" },
+    { url = "https://files.pythonhosted.org/packages/40/34/b193b3e6985469a2f8afa86c90012329c86480b6ff4f2e4bd7b5b937e134/librt-0.12.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:113417b934fbf38220a9c7fe94578cefbe7dbb047adcb75aa197905af2b13724", size = 519486, upload-time = "2026-06-30T16:12:34.996Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9e/7de4947b1695f247c813f833e3c1e7b77b52e52a7dba2c35411cf806b58e/librt-0.12.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:762f17c0eb6b5d74e269126996cea8a89e35ab6464c5151619163abcd8623ae2", size = 499609, upload-time = "2026-06-30T16:12:36.663Z" },
+    { url = "https://files.pythonhosted.org/packages/59/11/f3730e04e758b1fbf215359062ad2d5b6bd0b0ab5ac46b1c140628795be7/librt-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6aa93b3bd7f7588c628f6e9bf66485d3467fd9a1ccdb8975b770178f39f35697", size = 542205, upload-time = "2026-06-30T16:12:38.56Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8f/710453617eabe20e18433864f335534c8aff63fbc68d8cd9dbc70a3d08f6/librt-0.12.0-cp311-cp311-win32.whl", hash = "sha256:aaa04b44d4fe86d824616b1f9c13e34c7c01ec0c96dd2abc4f59423696f788e2", size = 98067, upload-time = "2026-06-30T16:12:40.102Z" },
+    { url = "https://files.pythonhosted.org/packages/42/53/401bff50a56e95daf151d911c99adf5732af2190e8f4d11886c9a229103c/librt-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:9aaeeddb8e7e4ae3bb9f944e0e618418cb91c0071d5ddbfcc3584b3cf59d39f0", size = 118346, upload-time = "2026-06-30T16:12:41.388Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/9a/a3a9078fe88bfc2d2d99dcf1c18593938ae830089cf84c3b2532a6c49d63/librt-0.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:18a2402fa3123ab76ecca670e6fb33038fde7c1e91181b885226ec4d30af2c2c", size = 104760, upload-time = "2026-06-30T16:12:43.112Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1a/5bec493821b0e85b91de4f234912b50133d1aedb875048eef27938ec3f96/librt-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9bce19aa7c05f91c989f9da7b567f81d21d57a2e6501e2b811aa0f3f79614c1a", size = 146756, upload-time = "2026-06-30T16:12:44.395Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d0/cc04b48a57c1f275387f5578847214c4a6c21bfb24c6c8c8d6ba753fe403/librt-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0ace09f5bf4d982fe726015f102fb856658b41580597104e301e630ed1d8d86", size = 145537, upload-time = "2026-06-30T16:12:45.95Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/10/c02325556beb2aa158c9e549ddade8cc9a23b36cdad14756dbed730c1ff1/librt-0.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d007efe9243ede81ce75990ad7aa172da1e2024144b3eff17ba46a5fff1fff3c", size = 488637, upload-time = "2026-06-30T16:12:47.658Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9e/7b49ca1c30baa9c8df96024aa09a97c35a97455e36004c9b5311703c56f3/librt-0.12.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:ad324a5e4858388a4864915b90a42efc8b374376393f14b9940f2454e791912b", size = 483651, upload-time = "2026-06-30T16:12:49.283Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/71/03c8c8cec39645fda451132ff9d6d662fc5aea42a1a188a77a4fddb35906/librt-0.12.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10a40cf74cdd97b6f8f905056db73f5d459783de2ca04c6ebd1bf47652818e7e", size = 518359, upload-time = "2026-06-30T16:12:50.999Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ec/a9f357f94bbcba92277d22af22cff42ef706ae5d9d6d58b69bebf3a67954/librt-0.12.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:92e61c09de95217ae02a9d17f4f66cf073253cdc51bcfdc0f15c62c9a70baa85", size = 509510, upload-time = "2026-06-30T16:12:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/34/717055325d028743aa01a7691ad59a63352a26a8ff2e7eeb0c9249514150/librt-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0461344061d6fc3718940f5855d95647831cef6d03a6c7506897f98222784ad4", size = 527302, upload-time = "2026-06-30T16:12:54.244Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/7612eeedb3395d92f7c6a84dca5f15e282d650483a4dc01aa5b9cffdfda3/librt-0.12.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e6dfe89074732c9287b3c0f5a6af575c9ede380a788013876cc7b14fe0da0361", size = 532568, upload-time = "2026-06-30T16:12:55.74Z" },
+    { url = "https://files.pythonhosted.org/packages/79/1e/a9afe85d5bb8b65dc27be3809ed1d69082079e1e9717fd2c66aa9939600c/librt-0.12.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9efed79d51ad1383bba0855f613cca7aa91c943e709af2413ac7f4bb9936ce08", size = 521579, upload-time = "2026-06-30T16:12:57.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/93aebb219d52c37ea578f83b0588cd7b040974e464d4e435086a48b4dc4d/librt-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1eac6cc0e23e448fb3c1446ed85ff796afb616eed5897c978d35dbec030b7c7c", size = 558743, upload-time = "2026-06-30T16:12:59.577Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/85/1680c0ec332f238e3145c5608d313ab0a43281e210a5dd87e3bc3cc25631/librt-0.12.0-cp312-cp312-win32.whl", hash = "sha256:0ab8ee0210047ae86ca023ccfbfe3df82077fd1c9bc021aebbf37d993ef64af0", size = 99200, upload-time = "2026-06-30T16:13:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/30/0e/abca12d8904875aa2ad66327390a3f7b1b75ebc43c0a00fc763cecf32ea5/librt-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:51c8bfa12632c81b94401c101bcedd0c56c3a1f8fa3273ca3472b28cd2f54003", size = 119390, upload-time = "2026-06-30T16:13:02.493Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a5/4203481b6d3a3bb348c82ac71abf1fcb4cb3ae8422a24a8dee4cd3ac5bd7/librt-0.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:5eebd451f5def089369ba6d8ff0291303d035e8154f9f26f7633835c5b029ade", size = 105117, upload-time = "2026-06-30T16:13:03.952Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/87/568d948c8079c9ff3c9e8110cf85f1eb70218e1209af29d0b7b89aa4a60c/librt-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8d9a55760a34ae5ce70434aabb6a6c61c6c44a0ec58ca1cfd9cd86e4745d417d", size = 146808, upload-time = "2026-06-30T16:13:05.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/1d/bea471ecea210088847bb5f3c4b4b424d596518934c06679b78ca85d6e63/librt-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ff0b197e338b4cf432873e0d6ef025213fdea85311ec4d87d2ea88c28adf2409", size = 145503, upload-time = "2026-06-30T16:13:07.023Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9e/984ad422b56de95fdce158f06b051655373784ebea0aba9a7fcbc41614d1/librt-0.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7e69f120a20b69e2539d603bbd4d62db38399b10f8bf73a1cf445038a621e8af", size = 488421, upload-time = "2026-06-30T16:13:08.492Z" },
+    { url = "https://files.pythonhosted.org/packages/50/03/1a2f94009b07ea71f8e1a4cfe53370565b56da9caa341b89e0699325e9f5/librt-0.12.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:fde3cde595e947fc8e755b0a21f919a1622483d07c662d00496e040773d22591", size = 483488, upload-time = "2026-06-30T16:13:10.169Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/3b/084bdc295823fbb6ab91670047adf8f420787f9e8794bf2d140b66dc196b/librt-0.12.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d977447315fa09ea4e8c7ae9b4e22f7659b5128161c1fd55ff786b5349f73503", size = 518428, upload-time = "2026-06-30T16:13:11.681Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/22/5a307390b93a115ffbecd95c64eecb4e56269680e45e9415ada7285f2cf4/librt-0.12.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7ffac8a67e4143cea9a549d4822b93bc0bbaad73fc25aa0ab0ba5ec27d178677", size = 509744, upload-time = "2026-06-30T16:13:13.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/90/83f3cb6184f5d669660717b4b2e317c9ddaccf7ca5bb97f2196deac1a3b7/librt-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:94af1ed773ff104ef08ef3d669a0ba9d3a5916c609eb698cffe5d5476d66ff9b", size = 527749, upload-time = "2026-06-30T16:13:15.277Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/3b/f162be5cc88d47378e3a20776fe425fa1c2bece755da15e2783ebf06d3d6/librt-0.12.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:548199d21d22fb26398dfbbe0ba953a52465c66f3a49f38e6fddce1b127faf53", size = 532582, upload-time = "2026-06-30T16:13:17.074Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/28/6c5d2f6b7232fd24f284fc4cab37a459fe69a9096a09942f44cc5c55e073/librt-0.12.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c8f1f413b966a9dd3ecf80cd337b0ad7bb3de2474a4ff448ed3ebabfc3f803fc", size = 522235, upload-time = "2026-06-30T16:13:18.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/1c/bd115360587fdc22c8ae8fac14c040a556b442e2965d4370d2cf274c8b95/librt-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:55f13f95b629be5b6ab38918e439bf14169d6f9a8deaae55e0c14e12fb0c74b9", size = 559055, upload-time = "2026-06-30T16:13:20.509Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5a/c26f49f576437014825a86faea3cec60c1ed17f976abd567b6c12b8e35a7/librt-0.12.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:8b2dc079dfe29e77a47a19073d2040fa4879aa3656501f1650f8402ddce0313c", size = 79809, upload-time = "2026-06-30T16:13:22.401Z" },
+    { url = "https://files.pythonhosted.org/packages/69/0b/a55244261d9ad7375ac039b8af06d42602722e2e8b8d8d6b86e4a3888c02/librt-0.12.0-cp313-cp313-win32.whl", hash = "sha256:da58944be8270f2bfee628a9a2a60c1cf6a12c8bea8e2c9b6edf3e5414ca7793", size = 99308, upload-time = "2026-06-30T16:13:23.661Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/bf/ed9465e58d44c5a5637795547d0841c8934aab905ea452cac1adf14672cf/librt-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:1db4be3037e4ce065a071fa7deee93e78ebc25f448340a02a6c1c0b82c37e383", size = 119438, upload-time = "2026-06-30T16:13:25.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/44/3cad652aeb892e6e8ffe48d0fafa2bc652f28ec7ed3f4403fcbb1be4f948/librt-0.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:05fd2542892ad770b5dd45003fd080477cf220b611d3ee59b0792097eb0873a9", size = 105118, upload-time = "2026-06-30T16:13:26.533Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/3a0e05618c12423b6fc5141b590ec02a6efb645833edc8736a6c7b46d1ec/librt-0.12.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:b37ee42e09722284a6d9288fe44a191f7276060a3195939bb77c6502058dbb34", size = 145579, upload-time = "2026-06-30T16:13:27.909Z" },
+    { url = "https://files.pythonhosted.org/packages/77/9e/fd399d099dfb4020f3f7c34e7e6210c389fa89f7d79ca92f5afb0395f278/librt-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ade11988728b3e4768dadc5696e82c60e9b35fc95335a9b4d1f5d69e753ccec7", size = 150139, upload-time = "2026-06-30T16:13:29.357Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ee/610239fbd8c4b005443664c5d4c3bc1717daedd8c71369bf45011aa87194/librt-0.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f351ed425380e39bd86df382578aa5b8c5b98e2e265112de7379e7d030258150", size = 480457, upload-time = "2026-06-30T16:13:30.78Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/10/ceddc9010f26c541444be36e1153a79b64626694db2d33a524c719fa3e46/librt-0.12.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:857d2163e088c868967717ace8e980017fd868a735f3de010412af02bdc30319", size = 479002, upload-time = "2026-06-30T16:13:32.398Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f1/b1523d9718e8192e5403e6b41a02742e17ba554369f0729b9f30ab590e2d/librt-0.12.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2befc80aa5f2f5b93f28abaaf11feff6677931dd548320e44c52deaa9399744", size = 510527, upload-time = "2026-06-30T16:13:34.615Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0e/0f3ff43befb18a531615736791e52fb67eaa71ff7b89e6e5f7004b64cc6e/librt-0.12.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:be3694dcfa97c6715dd19ac73d3e1b21a805514a5785663e57fecacd3ff64e5a", size = 500988, upload-time = "2026-06-30T16:13:36.408Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/1a/0278ea4a9e599dc507c43839a87f2c764ad04bf69418e2d763d58659e55f/librt-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2d5f67e86f45638843d025b0828f2e9e55fc45ff9180d2618ccdeaf72a796050", size = 519318, upload-time = "2026-06-30T16:13:37.883Z" },
+    { url = "https://files.pythonhosted.org/packages/59/55/090e10e62be2f35265e41601337f83ac9f83be9aca1bf92692e3a82effdd/librt-0.12.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:64572c85e4ab7d572c9b72cd76b5f90b21181b1459fa6b1aac6f8958c4fcff31", size = 527127, upload-time = "2026-06-30T16:13:39.682Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/34/8052c9ec678be6ba751279947831f089aa69b009000b985ce91d1979669a/librt-0.12.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:8b961912b0e688c1eb4658a46bdb0606b31918d65597fbe7356ca83aa653ffcc", size = 509766, upload-time = "2026-06-30T16:13:41.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/f8/8761b36189e9ec8dc20b49fa84cef22852c6c41fcda56f760f7fc1360da5/librt-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:722375903e3f079436a7a33da51ce73931536dd041f9feb01536f05d8e010c96", size = 552043, upload-time = "2026-06-30T16:13:43.197Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/98/7283971ef6b70269938b49c7b25f670ec6325d252265fbcc996f9b364379/librt-0.12.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:a5a96a8f536b65ef1bf910c09e7e71647edde5111f6e1b51f413c6fba5bfe71b", size = 79472, upload-time = "2026-06-30T16:13:44.64Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/5e/b30940dea935e8ac5bd0e0abb1985f5274590d557ac3a252ca0d5392ce52/librt-0.12.0-cp314-cp314-win32.whl", hash = "sha256:8ffc99c356f1777c506e1b69dc303879153ae2640ba15b8f3d4448bc87139149", size = 94246, upload-time = "2026-06-30T16:13:45.962Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/4e/0af9fe63f35fa304da3b05688f30ff6a329bcc59581b1cc51dc87fd30141/librt-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:1e68fb20798f455cda41d20a306a23c901218883f17a4bab1ed6e1331b265fb7", size = 114951, upload-time = "2026-06-30T16:13:47.279Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/8e/843c495d7db35e13b84cd533898fa89145c40dc255da0bc316d53d631464/librt-0.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:2df534f97916cf38ec9b1ddafeb68ae1a4cd4a54775ff26a797026774c0517cf", size = 100562, upload-time = "2026-06-30T16:13:48.699Z" },
+    { url = "https://files.pythonhosted.org/packages/75/30/c686d0f978d5fd6867c5bbad96b015c9445746764d1c228e16a2d30d9382/librt-0.12.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c09e581b1c2b8a62b809d4f4bd101ca3de93791e5b0ed1a14085d911be3dee3f", size = 153897, upload-time = "2026-06-30T16:13:50.017Z" },
+    { url = "https://files.pythonhosted.org/packages/40/46/f6f2d77ce46628b48fb5280709013b5109cf3a2c46a2472093cdfc03519d/librt-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:976888d0d831402086e641018bcc3208e0a38f0835789da91f72894b2cb4161f", size = 156391, upload-time = "2026-06-30T16:13:51.462Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/46/cd790c7e19e460779471530ffab454541d6ea4a3b7d338cad7f16ff96995/librt-0.12.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:563c37cdb41d08fe1e3f08b201abac0e317ca18e88b91285466ee0a585797520", size = 564151, upload-time = "2026-06-30T16:13:53.146Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/724559a15fb023cbdef7aee1e81fbfbc3ee22fd09009baa816cea63e3a60/librt-0.12.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:b97eb1a3140e279cc76f85b0fb92b7eb3dfbe0471260ee878bc9dc4bf9a0d649", size = 546002, upload-time = "2026-06-30T16:13:54.665Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/7e/f9d8c257ab4909f101c7c13734367749e782fd8625545f0343502c2f09f1/librt-0.12.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:06e0623351ab9904cf628245f99c714586f4dd23dc740b88c8bc670d8401a847", size = 584204, upload-time = "2026-06-30T16:13:56.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/33/64665810575ac23b6cb6ef364de51309b7803620c12885b6e895ebc29591/librt-0.12.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da12f017b2e404554be14d466cd992459feaa44f252b0f18d909a85266ce1237", size = 573688, upload-time = "2026-06-30T16:13:58.1Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/01/27522995c6627455abc7a939d57535fb1a7836d398ccedb3d7585f46039e/librt-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d97f31003a5c86b9e78155a829572c3a26484064fb7ac1d9695fe628bd93d029", size = 604719, upload-time = "2026-06-30T16:13:59.831Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/1f/099e61b1b688551d6d2ce9d4d2ae2242a938759db8551e6cbac7f7176ee5/librt-0.12.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:bd43a6c69876aef4f04eaae3d3b99b0be64755fda274002fa445b92480bf664e", size = 598183, upload-time = "2026-06-30T16:14:01.457Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c1/050400249665503bdd5b83cec518fa7b183b609341c8dcd58161775c4226/librt-0.12.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c01755c72fca1dc6b8d5c2ed228b8e7b2ffe184675c22f0f05ebd8fe188b9250", size = 582559, upload-time = "2026-06-30T16:14:03.29Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d1/eef8f0e6722518b65a3d3bcd9309f9f44e208ce5d6728070820f988e7078/librt-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:625ae561d5fa36400856dcc27464400d047bc2d5e3446be88f437b03fefd72e4", size = 626375, upload-time = "2026-06-30T16:14:04.957Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/78/f0bb41a6f2bbd3c77bdcc66980dc0d69ca1192a0ecec25377afcc5e6db73/librt-0.12.0-cp314-cp314t-win32.whl", hash = "sha256:8d73191883553ee0739741544bf3b00aba2a1224e45d9580b30cbc29e21dc03b", size = 97752, upload-time = "2026-06-30T16:14:06.555Z" },
+    { url = "https://files.pythonhosted.org/packages/92/24/e279c27972ab051a070237cfa45728fa51670c3f22f1a4d391711e9f4c31/librt-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e1cbb037324e759f0afa270229731ff0047772667f3cb38ef5df2cabf0175ede", size = 119562, upload-time = "2026-06-30T16:14:07.908Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e6/42a475bfca683b0cd5366f6dd06580062b7e567bb8534d225c877c2f14f3/librt-0.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bca1472acbd473eff61059b4409f802c5a1bcb4cd0344d06f939df9c4c125d40", size = 104282, upload-time = "2026-06-30T16:14:09.29Z" },
 ]
 
 [[package]]
@@ -1153,11 +1156,11 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.1"
+version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/5f/007786743f962224423753b78f7d7acb0f2ade46d1604f2e0fa2bedf9020/mistune-3.3.2.tar.gz", hash = "sha256:e12ee4f1e74336e91aa1141e35f913b337c40bdf7c0cc49f21fb853a27e8b62f", size = 111284, upload-time = "2026-06-23T00:29:28.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
+    { url = "https://files.pythonhosted.org/packages/44/43/894c2cbbcbdf53b57d1257a249811abe2ee9ab7ef76af301b40f1c054533/mistune-3.3.2-py3-none-any.whl", hash = "sha256:a678a56387d487db7368ede4647cb2ba1deff22ce61f92343e4ebe0ddfce4f2d", size = 61554, upload-time = "2026-06-23T00:29:27.088Z" },
 ]
 
 [[package]]
@@ -1267,16 +1270,16 @@ python = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "2.0.3"
+version = "2.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/33/c225eaf898634bdda489a6766fc35d1683c640bffe0e0acd10646b13536d/mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8", size = 199083, upload-time = "2026-02-20T10:38:36.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/b6/e858701499d57eee8b3fd8e78168083956c6683ddbe727b46758b19e1119/mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594", size = 199578, upload-time = "2026-06-19T10:41:08.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/28/79f0f8de97cce916d5ae88a7bee1ad724855e83e6019c0b4d5b3fabc80f3/mkdocstrings_python-2.0.3-py3-none-any.whl", hash = "sha256:0b83513478bdfd803ff05aa43e9b1fca9dd22bcd9471f09ca6257f009bc5ee12", size = 104779, upload-time = "2026-02-20T10:38:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/fc/10ab7e80650a9c9e8f4f1105f8c8e73567f88ed0c06ada589ab81d38687c/mkdocstrings_python-2.0.5-py3-none-any.whl", hash = "sha256:30c837bbff016549f659fcba6539ac351303f0fd7e713c89a040611072236e9d", size = 104951, upload-time = "2026-06-19T10:41:07.378Z" },
 ]
 
 [[package]]
@@ -1340,7 +1343,7 @@ wheels = [
 
 [[package]]
 name = "nbclient"
-version = "0.10.4"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-client" },
@@ -1348,9 +1351,9 @@ dependencies = [
     { name = "nbformat" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/91/1c1d5a4b9a9ebba2b4e32b8c852c2975c872aec1fe42ab5e516b2cecd193/nbclient-0.10.4.tar.gz", hash = "sha256:1e54091b16e6da39e297b0ece3e10f6f29f4ac4e8ee515d29f8a7099bd6553c9", size = 62554, upload-time = "2025-12-23T07:45:46.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/a5/b3bae4b590c0cbcada2c63a34f7580024e834a8ba213e949a2f906705787/nbclient-0.11.0.tar.gz", hash = "sha256:04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a", size = 62535, upload-time = "2026-06-05T07:52:41.746Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/a0/5b0c2f11142ed1dddec842457d3f65eaf71a0080894eb6f018755b319c3a/nbclient-0.10.4-py3-none-any.whl", hash = "sha256:9162df5a7373d70d606527300a95a975a47c137776cd942e52d9c7e29ff83440", size = 25465, upload-time = "2025-12-23T07:45:44.51Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c9/94d73e5a01c5b926c3fa2496e97d7a8dc28ed5a77c0b2ed712f1a62e6694/nbclient-0.11.0-py3-none-any.whl", hash = "sha256:ef7fa0d59d6e1d41103933d8a445a18d5de860ca6b613b87b8574accdb3c2895", size = 25288, upload-time = "2026-06-05T07:52:40.115Z" },
 ]
 
 [[package]]
@@ -1394,12 +1397,12 @@ wheels = [
 ]
 
 [[package]]
-name = "nest-asyncio"
-version = "1.6.0"
+name = "nest-asyncio2"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
 ]
 
 [[package]]
@@ -1413,18 +1416,19 @@ wheels = [
 
 [[package]]
 name = "notebook"
-version = "7.5.6"
+version = "7.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "jupyter-builder" },
     { name = "jupyter-server" },
     { name = "jupyterlab" },
     { name = "jupyterlab-server" },
     { name = "notebook-shim" },
     { name = "tornado" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/c2/cf59bd2e6f2c8b976b52477e3e53bf6f97bc714ed046a51821afb428eaee/notebook-7.5.6.tar.gz", hash = "sha256:621174aade80108f0020b0f00738000b215f75fa3cd90771ad7aa0f24536a4e1", size = 14170814, upload-time = "2026-04-30T11:46:26.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/44/d5c65783f490298473bb1c05722e05ee2256231389559c2c5ae0a3e5d975/notebook-7.6.0.tar.gz", hash = "sha256:ea13e79e601bf273074895fdfb17dd3f2da916d3c045e0b9c47d18b16ab62481", size = 5497344, upload-time = "2026-06-18T16:18:55.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/d6/1fd0646b9bbd9efbb0b8ae21b2325fbef515769a5621c03e31d8eb8da587/notebook-7.5.6-py3-none-any.whl", hash = "sha256:4dde3f8fb55fa8fb7946d58c6e869ce9baf46d00fc070664f62604569d0faca0", size = 14581730, upload-time = "2026-04-30T11:46:22.342Z" },
+    { url = "https://files.pythonhosted.org/packages/93/d1/e617c40db57ff40e75f43a7d4d1c305e3a54c053ab5cb0534a6c314664f9/notebook-7.6.0-py3-none-any.whl", hash = "sha256:98aa2811b54ac191321d5dfce12ca700f8a511a33a26e4de2fa106a357c43d6a", size = 5544575, upload-time = "2026-06-18T16:18:52.551Z" },
 ]
 
 [[package]]
@@ -1576,7 +1580,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.15' and sys_platform == 'emscripten') or (python_full_version < '3.15' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1880,15 +1884,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]
@@ -1902,7 +1906,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/80/5a/3806f44eb47387e8a
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1911,9 +1915,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1956,15 +1960,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.4.0"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/12/38c1a0b1e64806780c9563e3fc9f6e472251839662587cfbe9bfaf2ae10a/python_discovery-1.4.0.tar.gz", hash = "sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3", size = 68455, upload-time = "2026-05-28T01:15:37.639Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/26/8b004cc36f430345136f6f00fa1aa9ed596c8ed1e8504625fa79522ff39c/python_discovery-1.4.3.tar.gz", hash = "sha256:ad57d7045a862460d4a235986c33f13ed707d3aeb9153fa47eb7dfd0d4673289", size = 70438, upload-time = "2026-07-03T13:21:51.621Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/8d/3d316429f65029532bb1e28ff77b797d86b5ac3915bb44ca4e19aa283d43/python_discovery-1.4.0-py3-none-any.whl", hash = "sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da", size = 33217, upload-time = "2026-05-28T01:15:36.573Z" },
+    { url = "https://files.pythonhosted.org/packages/28/78/9b77ecb4644d1bbea94d29abf78f21c47eca6eb79e9745b702ec0bed2e19/python_discovery-1.4.3-py3-none-any.whl", hash = "sha256:b6e1e4a7d9e3f6948c39746ffe8218225162d738ba39d05ab1d2f6c1cac4878c", size = 33885, upload-time = "2026-07-03T13:21:50.174Z" },
 ]
 
 [[package]]
@@ -1987,22 +1991,22 @@ wheels = [
 
 [[package]]
 name = "pywinpty"
-version = "3.0.3"
+version = "3.0.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/54/37c7370ba91f579235049dc26cd2c5e657d2a943e01820844ffc81f32176/pywinpty-3.0.3.tar.gz", hash = "sha256:523441dc34d231fb361b4b00f8c99d3f16de02f5005fd544a0183112bcc22412", size = 31309, upload-time = "2026-02-04T21:51:09.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/2d27f30c59a67be7025b2d7858c8c2d282b74d66544b2384730b82de74fd/pywinpty-3.0.5.tar.gz", hash = "sha256:61db0db063de9865adbea66db294628f8577f608d9764a4c7d3384eeacc4e81b", size = 16223484, upload-time = "2026-06-11T00:11:58.93Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/c3/3e75075c7f71735f22b66fab0481f2c98e3a4d58cba55cb50ba29114bcf6/pywinpty-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:dff25a9a6435f527d7c65608a7e62783fc12076e7d44487a4911ee91be5a8ac8", size = 2114430, upload-time = "2026-02-04T21:54:19.485Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/1e/8a54166a8c5e4f5cb516514bdf4090be4d51a71e8d9f6d98c0aa00fe45d4/pywinpty-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:fbc1e230e5b193eef4431cba3f39996a288f9958f9c9f092c8a961d930ee8f68", size = 236191, upload-time = "2026-02-04T21:50:36.239Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/d4/aeb5e1784d2c5bff6e189138a9ca91a090117459cea0c30378e1f2db3d54/pywinpty-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c9081df0e49ffa86d15db4a6ba61530630e48707f987df42c9d3313537e81fc0", size = 2113098, upload-time = "2026-02-04T21:54:37.711Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/53/7278223c493ccfe4883239cf06c823c56460a8010e0fc778eef67858dc14/pywinpty-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:15e79d870e18b678fb8a5a6105fd38496b55697c66e6fc0378236026bc4d59e9", size = 234901, upload-time = "2026-02-04T21:53:31.35Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/cb/58d6ed3fd429c96a90ef01ac9a617af10a6d41469219c25e7dc162abbb71/pywinpty-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9c91dbb026050c77bdcef964e63a4f10f01a639113c4d3658332614544c467ab", size = 2112686, upload-time = "2026-02-04T21:52:03.035Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/50/724ed5c38c504d4e58a88a072776a1e880d970789deaeb2b9f7bd9a5141a/pywinpty-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:fe1f7911805127c94cf51f89ab14096c6f91ffdcacf993d2da6082b2142a2523", size = 234591, upload-time = "2026-02-04T21:52:29.821Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ad/90a110538696b12b39fd8758a06d70ded899308198ad2305ac68e361126e/pywinpty-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:3f07a6cf1c1d470d284e614733c3d0f726d2c85e78508ea10a403140c3c0c18a", size = 2112360, upload-time = "2026-02-04T21:55:33.397Z" },
-    { url = "https://files.pythonhosted.org/packages/44/0f/7ffa221757a220402bc79fda44044c3f2cc57338d878ab7d622add6f4581/pywinpty-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:15c7c0b6f8e9d87aabbaff76468dabf6e6121332c40fc1d83548d02a9d6a3759", size = 233107, upload-time = "2026-02-04T21:51:45.455Z" },
-    { url = "https://files.pythonhosted.org/packages/28/88/2ff917caff61e55f38bcdb27de06ee30597881b2cae44fbba7627be015c4/pywinpty-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:d4b6b7b0fe0cdcd02e956bd57cfe9f4e5a06514eecf3b5ae174da4f951b58be9", size = 2113282, upload-time = "2026-02-04T21:52:08.188Z" },
-    { url = "https://files.pythonhosted.org/packages/63/32/40a775343ace542cc43ece3f1d1fce454021521ecac41c4c4573081c2336/pywinpty-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:34789d685fc0d547ce0c8a65e5a70e56f77d732fa6e03c8f74fefb8cbb252019", size = 234207, upload-time = "2026-02-04T21:51:58.687Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/54/5d5e52f4cb75028104ca6faf36c10f9692389b1986d34471663b4ebebd6d/pywinpty-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0c37e224a47a971d1a6e08649a1714dac4f63c11920780977829ed5c8cadead1", size = 2112910, upload-time = "2026-02-04T21:52:30.976Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/44/dcd184824e21d4620b06c7db9fbb15c3ad0a0f1fa2e6de79969fb82647ec/pywinpty-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:c4e9c3dff7d86ba81937438d5819f19f385a39d8f592d4e8af67148ceb4f6ab5", size = 233425, upload-time = "2026-02-04T21:51:56.754Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5c/31feb3dd82d1b33ae0bd09ca601edb993d9da1b7f0226b3336d4b4c39e1e/pywinpty-3.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:af7a8720c78776ddd6259b71dd567944f766a6cd67f8d2887fbc4973967bacda", size = 2092466, upload-time = "2026-06-10T23:44:24.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/fe/fe23e2229ffec0c10190cef5964f5c9b2dba179d23b69ae537b7ea90bcab/pywinpty-3.0.5-cp311-cp311-win_arm64.whl", hash = "sha256:c2406f54f699eab75953fb75ce805f2ae55a33a957cd070890abd454fb4b7680", size = 818395, upload-time = "2026-06-10T23:41:56.93Z" },
+    { url = "https://files.pythonhosted.org/packages/45/34/942cc95ca4e26489875aa8a95192766247a687379ec29543eebe73ec945f/pywinpty-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:d62946adf14b15b54c0b8d785f93fe18b04da23f4ad59e2e8c4612646e9abd23", size = 2090915, upload-time = "2026-06-10T23:43:14.98Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/5b9053004844139ea8bd86209c57ade12b134b2782f383a095784c8531ec/pywinpty-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:e9391c05fbfa7a992a97e831fc6849887b4014a614192e3d984a7ca59592b376", size = 815934, upload-time = "2026-06-10T23:41:42.384Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:48db1b0ad9d0a1b81dcaaa7163a99a7808deaceb0c1b2344716dc1fc090c3c4c", size = 2090471, upload-time = "2026-06-10T23:42:11.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/a138491a0afbdb50eb79395577bd326d4b0fbde7209417d1a8087ff2493a/pywinpty-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:2c6008fb2d3774b48693b2fcb7f2cc317ade9dc581289a964ffeeaf81307c9b5", size = 815518, upload-time = "2026-06-10T23:42:02.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/15/54400049a380582acd1282665c70fcf11e0bd3713679aca78e24c3aae738/pywinpty-3.0.5-cp313-cp313t-win_amd64.whl", hash = "sha256:22ce1b780d89821cc52daf6eac0708af22d93d000ce9c7c07e37489db8594598", size = 2089920, upload-time = "2026-06-10T23:44:13.395Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0c/6f24f3c0799f502259b24bdf841a99ad2b0d59df5c2525b4e2a286d14be2/pywinpty-3.0.5-cp313-cp313t-win_arm64.whl", hash = "sha256:9c2919a81bc5cfb09b86fc5a002112b2de95ca4304a07413cbeeb746a1307a5c", size = 814520, upload-time = "2026-06-10T23:43:28.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/23/f3cd1b1e5fc56517f54452c49f92049e7dd9ffc8a63de22a495581f50d04/pywinpty-3.0.5-cp314-cp314-win_amd64.whl", hash = "sha256:03bb3c16d691d9242267201830bcd0e64a9b663170e9042bc84b210da9de15ac", size = 2090663, upload-time = "2026-06-10T23:43:59.845Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/dd/96d6cbfc6d9ddab5c1c2f92c26545ae8997446a2ba7ee2024cd43c81f49b/pywinpty-3.0.5-cp314-cp314-win_arm64.whl", hash = "sha256:89c5c6ef08997a3b4b277b214a35fe15cab4dd6d119f0140aa71df5b1168fdbc", size = 815700, upload-time = "2026-06-10T23:40:50.001Z" },
+    { url = "https://files.pythonhosted.org/packages/30/36/d98087bce0acaa4cce7f196103cfa7be3f63ce65f52473bb3e38784ae5d9/pywinpty-3.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7b566165e0c5fdd6abe167a5ac8b954be6a843eb55a85946576d6bc1dea03d6d", size = 2090093, upload-time = "2026-06-10T23:40:58.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fd/fe2b0db922ba052ce3976a08f3fc05d0c05047c8b4ebb6102e832b8ef563/pywinpty-3.0.5-cp314-cp314t-win_arm64.whl", hash = "sha256:24366280a8aa677323da87bec729cb3ea3b35367386cece0978bdc6e4695c690", size = 814517, upload-time = "2026-06-10T23:42:34.946Z" },
 ]
 
 [[package]]
@@ -2194,164 +2198,150 @@ wheels = [
 
 [[package]]
 name = "rpds-py"
-version = "2026.5.1"
+version = "2026.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/a0/acf8b6fc20bfdcd3a45bd3f57680fb198e157b7e997b9123b10763798bd2/rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036", size = 355609, upload-time = "2026-05-28T11:58:50.78Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/95/f8203fd997484b1690a6869cd0e503b6c3c6be55b0ecc36d1a491fe742f0/rpds_py-2026.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc", size = 348460, upload-time = "2026-05-28T11:58:52.374Z" },
-    { url = "https://files.pythonhosted.org/packages/33/8c/b47326ad2f0be545a5e5c1a55937a12afaea7d392ba2837bb9680f57e6c9/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0efbe45632665e53e3db8fe1e5692db58fc5cb9bab4459d570b83efefe11164", size = 381031, upload-time = "2026-05-28T11:58:53.775Z" },
-    { url = "https://files.pythonhosted.org/packages/22/0b/e83bbd97ffac6f6389b605cd4e1c8ac5761dc7e977769c9255d8c5adb7bd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead", size = 387121, upload-time = "2026-05-28T11:58:55.243Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/0e/d285d1bc8864245919c61e1ca82263e4a66d337759c3a4cef72766ff9afc/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7559f72b94ae52659086c595dfa017cde03155f7832071d30959049052cb3ece", size = 501026, upload-time = "2026-05-28T11:58:56.788Z" },
-    { url = "https://files.pythonhosted.org/packages/86/06/ccb2109a1e543437b5e43816f2b43b9554cc6783145528a4e3711e05c011/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e25b7088f9ccbfc0dfcaa52bf969300ca229e10ecf758974ebcbb080a4b37bb", size = 391865, upload-time = "2026-05-28T11:58:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/33/237173db1cfef10105b3839a24de00eb8d2a523711add4632447cdf0aedd/rpds_py-2026.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613fc4ee9eaef26dc5840666214dd6fbcebcf32f46e76f4abc473059f4e13dda", size = 378012, upload-time = "2026-05-28T11:58:59.589Z" },
-    { url = "https://files.pythonhosted.org/packages/97/64/1eae54e34d5161f9969295e80bd6b62a55f2b6ac5f2a5b60d02c2140e758/rpds_py-2026.5.1-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:85264a90ff4c05c1568dd65f5921c837614b67c60358fb4c17df3b7f2e90690a", size = 391111, upload-time = "2026-05-28T11:59:01.104Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/34/5bb334a5a0f65d77869217c4654f34c78a7d11b93938a3c076a2edeafc52/rpds_py-2026.5.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe71bca7d547acb17027c7fd1624ff8aae623499c498d3e7011182c4de5c25e0", size = 409225, upload-time = "2026-05-28T11:59:02.433Z" },
-    { url = "https://files.pythonhosted.org/packages/16/0f/007ec21283b5b040b4ec3bd95e0402591e22bfa7d5c93dfe01c465c2d2d7/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05fa4f41f37ec97c9c260441a940450a192f78d774d2b097eee1379f1e1246a", size = 556487, upload-time = "2026-05-28T11:59:04.012Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/10/5437c94508169b6b22d8418fef7a66e9ffb5f3b9e9c94460f2eedafe06ff/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df1d2a1996755b24b9ecee92cb4d36c28f86f464a6a173349c26bab41e94b8c2", size = 620798, upload-time = "2026-05-28T11:59:05.485Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d5/9937dce4d6bda74157b954e7d1460db05a22f5929dccfeeba1ed27a93df0/rpds_py-2026.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8895840ac4809e5f60c88fd07617cd71326e73d6e5a8aa783c5c0f7c24985de2", size = 584053, upload-time = "2026-05-28T11:59:06.837Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/31/750617dd0ae1752471bf43f9e41d263398fae7cde7849d23b8574a70e617/rpds_py-2026.5.1-cp311-cp311-win32.whl", hash = "sha256:3684a59b158a7683aaeb8e25352e9a9dd2122cec78f2d8530266e4f91b4c7b3f", size = 214390, upload-time = "2026-05-28T11:59:08.402Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/bb/3dcab0e1d9516303f2eb672a5d6f62eca5a69e2886301e9c8c54b520c39b/rpds_py-2026.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:7bd530e6a530bb3ea892f194fafa455f3516ac25ecf7143fd33c09be62b0470a", size = 231097, upload-time = "2026-05-28T11:59:09.786Z" },
-    { url = "https://files.pythonhosted.org/packages/49/d6/c6bbf5cb1cf12b9732df8074b57f6ef8341ba884c95d40632ae8bddb44e4/rpds_py-2026.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:0a5ae4dbe43c1076983b72616496919872ae7bbe7a1e21cc48336bc3154d130b", size = 226361, upload-time = "2026-05-28T11:59:11.079Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e7/a78582dc57caa592dcc7d4fb69b61390561e908eb3d2f5df5928a8e354c0/rpds_py-2026.5.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3abe24a66e57adcfa645d718063a5fa5103ecc71ddbf26d78af8f9368018ff1d", size = 353040, upload-time = "2026-05-28T11:59:12.531Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/43/35e3f136343aef451e545ce8c38d36c2f93c0ed88703db8b64ba2b205c68/rpds_py-2026.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:58b1d94308ddf0b1982f61f2eb54bf92997c9ece8a8093ef014250f4a517906c", size = 345775, upload-time = "2026-05-28T11:59:13.827Z" },
-    { url = "https://files.pythonhosted.org/packages/20/e1/0f2160c5982d3157734d5cb3ed63d8b2d583a73c9864f77b666449f32cf8/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fa92420128dadce7f54bd73ba1825a273e9268fe9e35dbf7e6362890efa4e08", size = 376329, upload-time = "2026-05-28T11:59:15.271Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/11/ee0ba42aff83bf4effdbc576673c6be64c5e173978c3f6d537e94482f77d/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca653c6546386227cd9800d1bef6a348099acf8db4250341da6d90f663d6dfcb", size = 383539, upload-time = "2026-05-28T11:59:16.665Z" },
-    { url = "https://files.pythonhosted.org/packages/11/df/d94aa6a499d4ac40afe2d7620f2c597fd3c0f182e854ad7cf3f596a81cb6/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66c93681c4729e4e3ecba31b8179fae083ff3118841672835140338b4b9867c1", size = 494674, upload-time = "2026-05-28T11:59:17.991Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/75/33d30f43bb2f458de11979486a591b1bf6e5651765ed1704c6197c2dc773/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ff257542e04796880e011e15cd4dc21c2599975df2aaa8f2c8495ca574e1a5", size = 389268, upload-time = "2026-05-28T11:59:19.434Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/1e/2c9096fc19d5fd084b0184ca2b651e659aa0a37e6fdbecf6ece47f147fe1/rpds_py-2026.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6825cc329b290e93c5f6a9be2393118a763f6ccf6abd83704e0c102ca583644", size = 376280, upload-time = "2026-05-28T11:59:21Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e5/61ec9f8be8211ea7f48448195549e4aaf02004083475493b0e137702ecb2/rpds_py-2026.5.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:de42116e69cb53b911cc34aee5ab98f36c597b822545045d49e938818b99e5e4", size = 387233, upload-time = "2026-05-28T11:59:22.454Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/ca/bcec1005c4f4a234f92a29078631fee49206c7265ccae966f18fd332e80e/rpds_py-2026.5.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c0f920015df2a504bebaba6d4c31ccf3fcf942f92655c086da30b671aad19aa6", size = 405009, upload-time = "2026-05-28T11:59:23.845Z" },
-    { url = "https://files.pythonhosted.org/packages/72/e6/4d5718c5cf26c522dc7c9999e238da1e77380b81d0c5d1df11e271ddfeb1/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0408a24e44feb919423dc6d9da677cb5cddb894d2ca9e763967d156d9c60fab4", size = 553113, upload-time = "2026-05-28T11:59:25.184Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/25/2ee807bdb3e1f0b7eddf7782acd5665a8b5205a331a7d7244a52c4812fd9/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cea68bcd53467561ae2f96a6bdad1544299ba97b5b0ddcd5ac3d376e5c781c24", size = 618838, upload-time = "2026-05-28T11:59:26.749Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c1/7d4c26f167f8c41501cc073d30ee22082b16ce358cf5b00ec97cbc7804ea/rpds_py-2026.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4be8b1d2a705cc37d08256004e1d07de143fa0075c8e85a3df020b776f62b732", size = 582436, upload-time = "2026-05-28T11:59:28.11Z" },
-    { url = "https://files.pythonhosted.org/packages/04/1d/9d12b0a337bab46f4769f8857f4007e3b2d639e14f9a44a0efe157696e64/rpds_py-2026.5.1-cp312-cp312-win32.whl", hash = "sha256:6736718bd4fc49cbcb538ba30516fdbef161522acefb739657d48b97bd864fed", size = 212734, upload-time = "2026-05-28T11:59:29.689Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/93/e4116f2de7f56bc7406a76033dc501811ddeb22b7f056b92d632871ebb0c/rpds_py-2026.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:0a7d1eec967df0e9b22614a5e177622e0c89611d03727fa0cb48e45028907870", size = 229045, upload-time = "2026-05-28T11:59:31.033Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/53/6c3419d85eb2ec5938a37627c585b42d76a63bb731d6e42ed4b079ebf486/rpds_py-2026.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1841d067089e117142d79b98aa0df2f08b52f2ecc1819dd2700636c0db74a473", size = 223967, upload-time = "2026-05-28T11:59:32.318Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
-    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
-    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
-    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
-    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
-    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
-    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
-    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
-    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
-    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
-    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
-    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
-    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
-    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
-    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
-    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
-    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
-    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
-    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
-    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
-    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
-    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
-    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
-    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
-    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
-    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
-    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
-    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
-    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
-    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
-    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
-    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
-    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
-    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
-    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
-    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
-    { url = "https://files.pythonhosted.org/packages/42/56/3fe0fb34820ff667be791b3a3c22b85e8bcba54e9c832f47438c191fa7be/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:edf2765d84e42447f112ad877af8fe1db0089aaec5b28e88d6eab45e7fe99cea", size = 357151, upload-time = "2026-05-28T12:01:53.43Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f2/3eb9ccdb9f143b8c9b003978898cb497f942a324c077401e6b8834238e63/rpds_py-2026.5.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ad3773236e95f7f33991eb125224b7da66f206504d032a253a02da7e134519fb", size = 350195, upload-time = "2026-05-28T12:01:54.901Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/24/dbda232bc4f3ed732120692ab0d2c8402cb020516556d8bee622dcef2413/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a04df86b3f0fade39ec8fd0e0aab089b1da9fbd2b48df778a57ef96f5e7d38df", size = 381850, upload-time = "2026-05-28T12:01:56.601Z" },
-    { url = "https://files.pythonhosted.org/packages/40/30/32e769839a358f78810c234f160f2cc21d1e4e47e1c0e0e0d535be5a0219/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6142dbd80c4df62a5d899f0d616d417f84e0bc8d32526c8e5589019d75d028a7", size = 387899, upload-time = "2026-05-28T12:01:58.212Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/86/ec84d243aadb3b34b71dd26a010d0930b2d284ff5fc9a69fec53810ee6fd/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0b35217adefe87f2fe4db7e9766cabe84744bfe9616d9667be18988928c7f2dc", size = 501618, upload-time = "2026-05-28T12:01:59.888Z" },
-    { url = "https://files.pythonhosted.org/packages/74/25/b60e52686bbff777a64f9e4f4d3dd57980dc846913777177a2c92e4937aa/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b95d5e11fc712b752081183a55a244c03cd00570489edd7014d8899f8ceb8162", size = 394003, upload-time = "2026-05-28T12:02:01.482Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/c7/b3a6a588cc2219510ef3f42e207483a93950bedd1e3a0fd4015c95cff9e5/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:141c9498daf2ace9eda35d2b0e376f9ea8b058d84f2aef4f96fccfd449a2f251", size = 379778, upload-time = "2026-05-28T12:02:03.197Z" },
-    { url = "https://files.pythonhosted.org/packages/31/00/c7dba3fc8a3da8cb3f6db1eb3386be4d79c2e97c6890d20eb9ac66ae8c43/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:6f249f8b860a200ad35193af961183ebe9132710484e6f6ce0cf89fd83c63a9a", size = 392359, upload-time = "2026-05-28T12:02:04.817Z" },
-    { url = "https://files.pythonhosted.org/packages/93/dd/472ba494c70753f93745992c99855bee0636daf74e6984e5e003f150316f/rpds_py-2026.5.1-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e4abbf391a70be864920858bf360f4fb380577c9a0f732438a1996726e2c195b", size = 412820, upload-time = "2026-05-28T12:02:06.401Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/6f/93831a3bfe789542ed0c1d0d74b78b440f055d6dc3ea4640eba2d95e6e23/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c74005a7bb87752acf351c93897ec63ad77a07a0da7ecad9c050e32e7286ba34", size = 557243, upload-time = "2026-05-28T12:02:08.013Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/ff/0b3d604614ffc77522c6b288fdbce68957eb583da1002aa65ba38ac0ee40/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:8213afbe8a3a906fb9acb2014423fe3359ee783d0bf90995f70623a3217bfa6c", size = 623541, upload-time = "2026-05-28T12:02:09.661Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/ea/e7b0251441da9adfeaebcf29601d10f2a1455fcf0772fae9e7e19032bd96/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8c43a8a973270fd173bf48cdf80bbe66312421cba68d40845034f174f2389049", size = 586326, upload-time = "2026-05-28T12:02:11.47Z" },
+    { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/dc/323d08583c0832911768663d1944f0107fcd4088704858d84b5e06d105a0/rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911", size = 345513, upload-time = "2026-06-30T07:14:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2a/e31989834d18d2f26ec1d2774c5b1eb3331df4ea8ada525175294c94b48a/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4", size = 373783, upload-time = "2026-06-30T07:14:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fe/e80107ee3639585c9941c17d6a42cd65325022f656c023191fce78c324c8/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261", size = 378316, upload-time = "2026-06-30T07:14:59.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/81e3adf81acfb6fa694de2a6e4e7d8863121e3e0799e0a7725e6cf5679c4/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278", size = 499423, upload-time = "2026-06-30T07:15:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/41263969df0ce3d9af2a96d5005a288200af1989aed3354bfceb5fc0b21f/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9", size = 386077, upload-time = "2026-06-30T07:15:01.911Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/7e98f468bd50346faff5b10e5297374b443bfdddacc8e9fbc65984539597/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7", size = 371315, upload-time = "2026-06-30T07:15:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3c/2b973b4d371906a134b03decfea7f5d9835a2c6d263454392e15b64b5b18/rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3", size = 383502, upload-time = "2026-06-30T07:15:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2a/12e2799500af0a307bca76b63361c51f9fe479223561489c29eea1f2ee41/rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da", size = 402673, upload-time = "2026-06-30T07:15:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e3/21e5872d165fe08be4f229e3d5ee9d90019c0bf0e5538de60dbd54009450/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4", size = 549964, upload-time = "2026-06-30T07:15:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/5ee0fe36844297de8123bee27bc12078c1a7416ad9f1b8a8ca18d6b0c0ac/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6", size = 615446, upload-time = "2026-06-30T07:15:08.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/1ea5873cb683f2fbe5f21b23ea1f6d179ead19f3c5b249b7eb5dca568ef2/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93", size = 576975, upload-time = "2026-06-30T07:15:09.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e1/90ef639217a5ddb15b7f4f61b1c33911fd044ad03c311bafdd2bcab85582/rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a", size = 204453, upload-time = "2026-06-30T07:15:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127", size = 223219, upload-time = "2026-06-30T07:15:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/145afacf796e4506062825941176ad9445c2dcf2b3b6a1f13d3030a15e19/rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804", size = 219137, upload-time = "2026-06-30T07:15:13.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/f0d19ac587fd0e4ab6b72cda355e9c5a6166b01ef7e064e437aef8eb9fef/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f", size = 349791, upload-time = "2026-06-30T07:17:33.315Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/1d49d204c9fd2ee6c537601dc4c1ba921e03363ca576bfab94a00254ac9a/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171", size = 352842, upload-time = "2026-06-30T07:17:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e5/c0b5dc93cd0d4c06ce1f438907649514e2ea077bcd911e3154a51e96c38e/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90", size = 382094, upload-time = "2026-06-30T07:17:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/54/ec0e907b4ca8d541112db352409bd15f871c9b243e0c92c9b5a46ae96f01/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca", size = 388662, upload-time = "2026-06-30T07:17:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/921c22a4fd0f1c1ac13a3996ffbf0aa67951e2c8ad0d1d9574938a2932e8/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9", size = 504896, upload-time = "2026-06-30T07:17:39.689Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1b/a114b972cefa1ab1cdb3c7bb177cd3844a12826c507c722d3a73516dbbaf/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c", size = 391545, upload-time = "2026-06-30T07:17:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/98/af9b3db77d47fcbe6c8c1f36e2c2147ec70292819e99c325f871584a1c11/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9", size = 380059, upload-time = "2026-06-30T07:17:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ba/0efd8668b97c1d26a61566386c636a7a7a09829e474fdf807caa15a2c844/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41", size = 393235, upload-time = "2026-06-30T07:17:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/8c139ee9690f73b0829f32647de6f40d826f8f443af6fa72644f96351aac/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c", size = 413008, upload-time = "2026-06-30T07:17:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
 ]
 
 [[package]]
 name = "ruff"
-version = "0.15.15"
+version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
-    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
-    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
-    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
-    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]
@@ -2361,15 +2351,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "82.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]
@@ -2392,7 +2373,7 @@ wheels = [
 
 [[package]]
 name = "sparkdq"
-version = "0.11.4"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -2492,14 +2473,14 @@ wheels = [
 
 [[package]]
 name = "tinycss2"
-version = "1.4.0"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
 ]
 
 [[package]]
@@ -2558,37 +2539,37 @@ wheels = [
 
 [[package]]
 name = "tornado"
-version = "6.5.6"
+version = "6.5.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/57/6d7303a77ae439d9189108f76c0c4fd89ee5e2cc8387bffb55232565c4ed/tornado-6.5.6.tar.gz", hash = "sha256:9a365179fe8ff6b8766f602c0f67c185d778193e9bdd828b19f0b6ed7764177d", size = 518139, upload-time = "2026-05-27T15:35:54.646Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/0d/b4f481e18c5a51864e6d12b9a05ecf72919696680b747c958c3fc1f4fbae/tornado-6.5.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:65fcfaafb079435c2c19dc9e07c0f1cf0fa9051759ed0a7d0a3ba7ea7f64919c", size = 447737, upload-time = "2026-05-27T15:35:38.122Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/9c/5430c39fcab1144d35860f457b15e9c08b4bc7ac86764354204e983d6183/tornado-6.5.6-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:38bc01b4acacded2de63ae78023548e41ebe6fbed3ec05a796d7ae3ad893887e", size = 445899, upload-time = "2026-05-27T15:35:40.519Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/79/fa7e14a2f939c807a8d30619b4eb604eab219601b78792516ebe22d40cf9/tornado-6.5.6-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b942e6a137fda31ff54bf8e6e2c8d1c37f1f50583f3ed53fb840b53b9601d104", size = 448964, upload-time = "2026-05-27T15:35:42.106Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/71/bd67d5f5199f937dafe03a49a37989f60f600ff6fef34c79412a829d97bd/tornado-6.5.6-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8666946e70171b8c3f1fc9b7876fac492e84822c4c7f3746f4e8f8bc9ac92a79", size = 449935, upload-time = "2026-05-27T15:35:43.906Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/a4/c24388c9cf5b3c3a513b56a158af9f23092c9a2810d789e294310797df21/tornado-6.5.6-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1c34cfab7ad6d104f052f55de06d39bbafc5885cfeb4da688803308dbcfa90b7", size = 449767, upload-time = "2026-05-27T15:35:45.793Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/eb/6a07ad550c3f7b37244bd0becdf293ec3d3e961783d8b720a97df50de1b2/tornado-6.5.6-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:385f35e4e22fb52551dfcda4cdc8c30c61c2c001aef5ddad99cdfe116952efd3", size = 449174, upload-time = "2026-05-27T15:35:47.485Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/84/3469e098dccdb6763130e06aacd786bb4363fca7b590a55c101ddf34ed30/tornado-6.5.6-cp39-abi3-win32.whl", hash = "sha256:db475f1b67b2809b10bb16264829087724ca8d24fe4ed47f7b8675cae453ef86", size = 450230, upload-time = "2026-05-27T15:35:49.322Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/3c/273a04e0b9dd9016f1685cca0c1c8795a71ac88a34a8c889a0b443483226/tornado-6.5.6-cp39-abi3-win_amd64.whl", hash = "sha256:6739bf1e8eb09230f1280ddbd3236f0309db70f2c551a8dbc40f62babdf82f79", size = 450667, upload-time = "2026-05-27T15:35:51.194Z" },
-    { url = "https://files.pythonhosted.org/packages/02/98/0cffe22a224f60c5fb1e3aa0b76f9da2e1ca78b0e9545e3d077c68ce60a7/tornado-6.5.6-cp39-abi3-win_arm64.whl", hash = "sha256:2543597b24a695d72338a9a77818362d72387c03ae173f1f169eadc5c91466ac", size = 449690, upload-time = "2026-05-27T15:35:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
+    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
 ]
 
 [[package]]
 name = "traitlets"
-version = "5.15.0"
+version = "5.15.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]
@@ -2632,7 +2613,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.4.1"
+version = "21.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -2640,9 +2621,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/f0/b47ecf438211a25a97f8f0e4b23c22bc2496ebfea18dd6ec16210f09cc36/virtualenv-21.4.1.tar.gz", hash = "sha256:2ca543c713b72840ceffd94e9bdedfbd09a661defa1f7f69e5429ad4059442e2", size = 7613344, upload-time = "2026-05-28T04:12:49.905Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/dc/ac4f3a987a87e1a18556896f257c4e15c95ed157b7975347ec6b313b75ce/virtualenv-21.4.1-py3-none-any.whl", hash = "sha256:caf4ff72d1b4039057f41d8e8466e859513d67c0400d9c6b62c02c9d1ebc3e12", size = 7594078, upload-time = "2026-05-28T04:12:47.686Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
 ]
 
 [[package]]
@@ -2674,11 +2655,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.7.0"
+version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2354,6 +2354,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2409,6 +2418,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
 ]
 
 [package.metadata]
@@ -2441,6 +2451,7 @@ test = [
     { name = "pytest", specifier = ">=8.3.5,<10.0.0" },
     { name = "pytest-cov", specifier = ">=7.1.0,<8.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'", specifier = ">=69.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
 ## Summary

  This branch brings the documentation and project presentation up to a
  professional, verified standard, and lands a performance improvement in the
  aggregate execution path.

  The largest part is documentation: a new architecture section, a reworked
  Getting Started guide, and a full expansion of every built-in check page — all
  with examples verified against a real Spark run.

  ## Highlights

  ### Engine
  - **Batch observable aggregate checks into a single Spark job.** Checks
    implementing `ObservableAggregateCheck` now contribute their aggregation
    expressions to one `df.agg()` call instead of triggering a separate job each,
    cutting full-table scans on aggregate-heavy check sets.

  ### Documentation
  - **Architecture section (new):** layered overview, core abstractions, execution
    flow, and output model, plus ADR-style design decisions (declarative config,
    plugin system, row-vs-aggregate split, observable aggregation, DataFrame
    annotations). Every claim verified against the source.
  - **Built-in checks:** all 33 check pages expanded to a consistent reference
    format — parameter table, Python + YAML usage, behavior notes for non-obvious
    semantics, and a runnable example with verified output.
  - **Getting Started:** reworked around a single end-to-end `orders` scenario that
    runs through all four pages, with real pass/fail/warn/summary output, a concept
    diagram, and practice tips.
  - **Landing page / README:** lead with what the framework does and position its
    deliberately small scope as a strength.
  - **Navigation:** ordered along the reader's path — Getting Started → Built-In
    Checks → Architecture → API Reference.

  ### Fixes
  - Add missing kebab-case aliases (`reference-dataset`, `reference-column`) to
    `ForeignKeyCheckConfig` so YAML configs validate.
  - Correct invalid documentation examples (non-existent `Severity.ERROR`, chained
    `add_checks_from_dicts`, inverted not-null semantics).

  ### Tooling / theme
  - Stop Prettier from reformatting `docs/` (it was breaking Material admonitions).
  - Widen check pages, relax table column widths, and style console-output blocks.
  - Upgrade locked dependencies.